### PR TITLE
[BE] feat: admin에서 인라인으로 데이터 관리

### DIFF
--- a/be/glossymatcha/admin.py
+++ b/be/glossymatcha/admin.py
@@ -1,71 +1,28 @@
 from django.contrib import admin
-from .models import Products, ProductImages, ProductSpecifications, Inquiries
-
+from .models import ProductImages, ProductSpecifications
 
 class ProductImagesInline(admin.TabularInline):
+    """
+    제품 이미지 인라인 클래스
+    - 제품 상세 페이지에서 관련된 이미지 데이터를 함께 관리할 수 있도록 설정
+    - 추가 이미지 입력 필드 제공 (extra=1)
+    - 표시 필드: 이미지, 이미지 타입, 정렬 순서, 한국어 대체 텍스트, 영어 대체 텍스트
+    - 생성일은 읽기 전용 필드로 설정
+    """
     model = ProductImages
     extra = 1
-    fields = ('image', 'image_type', 'sort_order')
-
+    fields = ('image', 'image_type', 'sort_order', 'alt_text_ko', 'alt_text_en')
+    readonly_fields = ('created_at',)
 
 class ProductSpecificationsInline(admin.TabularInline):
+    """
+    제품 사양 인라인 클래스
+    - 제품 상세 페이지에서 관련된 사양 데이터를 함께 관리할 수 있도록 설정
+    - 추가 사양 입력 필드 제공 (extra=1)
+    - 표시 필드: 스펙 키, 스펙 값 (한국어/영어)
+    - 생성일은 읽기 전용 필드로 설정
+    """
     model = ProductSpecifications
     extra = 1
-    fields = ('spec_key', 'spec_value')
-
-
-@admin.register(Products)
-class ProductsAdmin(admin.ModelAdmin):
-    list_display = ('name', 'category', 'created_at')
-    list_filter = ('created_at',)
-    search_fields = ('name', 'description')
-    readonly_fields = ('created_at', 'updated_at')
-    inlines = [ProductImagesInline, ProductSpecificationsInline]
-    
-    fieldsets = (
-        ('기본 정보', {
-            'fields': ('product_code', 'name', 'description', 'category', 'sort_order')
-        }),
-        ('시간 정보', {
-            'fields': ('created_at', 'updated_at'),
-            'classes': ('collapse',)
-        }),
-    )
-
-
-@admin.register(ProductImages)
-class ProductImagesAdmin(admin.ModelAdmin):
-    list_display = ('product', 'image_type', 'sort_order', 'created_at')
-    list_filter = ('image_type', 'created_at')
-    search_fields = ('product__name',)
-    list_editable = ('sort_order',)
-    ordering = ('product', 'sort_order')
-
-
-@admin.register(ProductSpecifications)
-class ProductSpecificationsAdmin(admin.ModelAdmin):
-    list_display = ('product', 'spec_key', 'spec_value', 'created_at')
-    list_filter = ('created_at',)
-    search_fields = ('product__name', 'spec_key', 'spec_value')
-    ordering = ('product', 'spec_key')
-
-
-@admin.register(Inquiries)
-class InquiriesAdmin(admin.ModelAdmin):
-    list_display = ('name', 'email', 'inquiry_type', 'created_at')
-    list_filter = ('inquiry_type', 'created_at')
-    search_fields = ('name', 'email', 'message')
-    readonly_fields = ('created_at', 'updated_at')
-    
-    fieldsets = (
-        ('문의자 정보', {
-            'fields': ('name', 'email')
-        }),
-        ('문의 내용', {
-            'fields': ('inquiry_type', 'message')
-        }),
-        ('시간 정보', {
-            'fields': ('created_at', 'updated_at'),
-            'classes': ('collapse',)
-        }),
-    )
+    fields = ('spec_key', 'spec_key_en', 'spec_value', 'spec_value_en', 'created_at')
+    readonly_fields = ('created_at',)


### PR DESCRIPTION
- 제품 이미지 인라인 클래스
  - 제품 상세 페이지에서 관련된 이미지 데이터를 함께 관리할 수 있도록 설정
  - 추가 이미지 입력 필드 제공 (extra=1)
  - 표시 필드: 이미지, 이미지 타입, 정렬 순서, 한국어 대체 텍스트, 영어 대체 텍스트
  - 생성일은 읽기 전용 필드로 설정
- 제품 사양 인라인 클래스
  - 제품 상세 페이지에서 관련된 사양 데이터를 함께 관리할 수 있도록 설정
  - 추가 사양 입력 필드 제공 (extra=1)
  - 표시 필드: 스펙 키, 스펙 값 (한국어/영어)
  - 생성일은 읽기 전용 필드로 설정