### PR TITLE
[FE] feat: 체험형콘텐츠 메인 페이지 마크업

### DIFF
--- a/fe/src/app/test/page.tsx
+++ b/fe/src/app/test/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import MatchaGenerator from "@/components/GlossyPick/MatchaGenerator";
+
+export default function test() {
+    return <MatchaGenerator />;
+}

--- a/fe/src/components/GlossyPick/Intro.tsx
+++ b/fe/src/components/GlossyPick/Intro.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+export default function Intro() {
+    return (
+        <>
+            <header>
+                <h1>Glossy Pick</h1>
+                <p>단 하나, 당신만을 위한 글로시 말차</p>
+            </header>
+            <p>몇가지 질문에 답하면 메뉴를 추천해드려요</p>
+            <img
+                src="/images/glossy-pick/intro.svg"
+                alt="글로시 말차 메뉴 이미지"
+            />
+            <button>시작하기</button>
+        </>
+    );
+}

--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import Intro from "./Intro";
+
+export default function MatchaGenerator() {
+    return (
+        <main>
+            <section>
+                <Intro />
+            </section>
+        </main>
+    );
+}


### PR DESCRIPTION
체험형 콘텐츠 메인(인트로) 페이지 마크업

- app/test/page.tsx 구현
- components/GlossyPick/MatchaGenerator.tsx 구현
- components/GlossyPick/Intro.tsx 구현
- 메인 페이지 이미지 추가