### PR TITLE
[FE] style: 체험형 콘텐츠 메인 페이지 스타일링

### DIFF
--- a/fe/src/components/GlossyPick/GlossyPickHeader.module.scss
+++ b/fe/src/components/GlossyPick/GlossyPickHeader.module.scss
@@ -1,0 +1,20 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+
+.glossy-pick-header {
+    margin: 100px 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 30px;
+
+    &__title {
+        @include myeongjo($font-size-50, 500);
+        color: $color-green-500;
+    }
+
+    &__subtitle {
+        @include pretendard($font-size-20, 500);
+    }
+}

--- a/fe/src/components/GlossyPick/GlossyPickHeader.tsx
+++ b/fe/src/components/GlossyPick/GlossyPickHeader.tsx
@@ -1,0 +1,14 @@
+import styles from "./GlossyPickHeader.module.scss";
+
+export default function GlossyPickHeader() {
+    return (
+        <header className={styles["glossy-pick-header"]}>
+            <h3 className={styles["glossy-pick-header__title"]}>
+                Glossy Pick
+            </h3>
+            <p className={styles["glossy-pick-header__subtitle"]}>
+                단 하나, 당신만을 위한 글로시 말차
+            </p>
+        </header>
+    );
+}

--- a/fe/src/components/GlossyPick/Intro.module.scss
+++ b/fe/src/components/GlossyPick/Intro.module.scss
@@ -1,0 +1,23 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+
+.intro {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 100px;
+
+    &__description {
+        @include myeongjo($font-size-28, 500);
+        margin-bottom: 90px;
+    }
+
+    &__image {
+        width: 100%;
+        max-width: 970px;
+        height: auto;
+        aspect-ratio: 970 / 420;
+        object-fit: cover;
+        margin-bottom: 90px;
+    }
+}

--- a/fe/src/components/GlossyPick/Intro.tsx
+++ b/fe/src/components/GlossyPick/Intro.tsx
@@ -1,18 +1,25 @@
 "use client";
 
+import Image from "next/image";
+import GlossyPickHeader from "./GlossyPickHeader";
+import styles from "./Intro.module.scss";
+
 export default function Intro() {
     return (
-        <>
-            <header>
-                <h1>Glossy Pick</h1>
-                <p>단 하나, 당신만을 위한 글로시 말차</p>
-            </header>
-            <p>몇가지 질문에 답하면 메뉴를 추천해드려요</p>
-            <img
+        <div className={styles.intro}>
+            <GlossyPickHeader />
+            <p className={styles["intro__description"]}>
+                몇 가지 질문에 답하면, 당신에게 어울리는 글로시 말차 메뉴를
+                추천해드려요.
+            </p>
+            <Image
+                className={styles["intro__image"]}
                 src="/images/glossy-pick/intro.svg"
                 alt="글로시 말차 메뉴 이미지"
+                width={970}
+                height={420}
             />
-            <button>시작하기</button>
-        </>
+            <button className="btn-g pc">시작하기</button>
+        </div>
     );
 }

--- a/fe/src/components/GlossyPick/MatchaGenerator.module.scss
+++ b/fe/src/components/GlossyPick/MatchaGenerator.module.scss
@@ -13,7 +13,8 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        width: 1280px;
+        max-width: 1280px;
+        width: 100%;
         margin: 240px auto;
         box-shadow: 0px 8px 25px 0px rgba(0, 0, 0, 0.15);
         border-radius: 24px;

--- a/fe/src/components/GlossyPick/MatchaGenerator.module.scss
+++ b/fe/src/components/GlossyPick/MatchaGenerator.module.scss
@@ -1,0 +1,21 @@
+@use "@/styles/variables" as *;
+@use "@/styles/mixins" as *;
+
+.matcha-generator {
+    &__banner {
+        width: 100%;
+        height: auto;
+        aspect-ratio: 1920 / 720;
+        object-fit: cover;
+    }
+
+    &__section {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 1280px;
+        margin: 240px auto;
+        box-shadow: 0px 8px 25px 0px rgba(0, 0, 0, 0.15);
+        border-radius: 24px;
+    }
+}

--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -1,11 +1,24 @@
 "use client";
 
+import Image from "next/image";
+import styles from "./MatchaGenerator.module.scss";
 import Intro from "./Intro";
 
 export default function MatchaGenerator() {
     return (
-        <main>
+        <main className={styles["matcha-generator"]}>
             <section>
+                <h2 className="sr-only">글로시 말차 체험형 콘텐츠 페이지</h2>
+                <Image
+                    className={styles["matcha-generator__banner"]}
+                    src="/images/glossy-pick/main-banner.svg"
+                    alt="체험형 콘텐츠 메인 배너"
+                    width={1920}
+                    height={720}
+                    priority
+                />
+            </section>
+            <section className={styles["matcha-generator__section"]}>
                 <Intro />
             </section>
         </main>


### PR DESCRIPTION
- 메인 배너 이미지 추가
- 체험형 콘텐츠 헤더 분리 (GlossyPickHeader 컴포넌트 구현)
- 각 컴포넌트 별 스타일링 (MatchaGenerator.scss, GlossyPickHeader.scss, Intro.scss)