### PR TITLE
[BE] fix: 전화번호는 숫자만 입력 가능하게 수정

### DIFF
--- a/be/glossymatcha/forms.py
+++ b/be/glossymatcha/forms.py
@@ -33,7 +33,10 @@ class StaffForm(forms.ModelForm):
             }),
             'contact': forms.TextInput(attrs={
                 'class': 'form-control',
-                'placeholder': '연락처를 입력하세요.'
+                'placeholder': '연락처를 입력하세요.',
+                'pattern': '[0-9-]+',
+                'inputmode': 'numeric',
+                'oninput': 'this.value = this.value.replace(/[^0-9-]/g, "")'
             }),
             'memo' : forms.Textarea(attrs={
                 'class': 'form-control',
@@ -133,7 +136,10 @@ class SuppliersForm(forms.ModelForm):
             }),
             'phone': forms.TextInput(attrs={
                 'class': 'form-control',
-                'placeholder': '연락처를 입력하세요. (선택사항)'
+                'placeholder': '연락처를 입력하세요. (선택사항)',
+                'pattern': '[0-9-]+',
+                'inputmode': 'numeric',
+                'oninput': 'this.value = this.value.replace(/[^0-9-]/g, "")'
             }),
             'email': forms.EmailInput(attrs={
                 'class': 'form-control',


### PR DESCRIPTION
### 이제 거래처와 직원 등록 시 전화번호 필드에 숫자와 하이픈(-) 외에는 입력할 수 없음
- pattern="[0-9-]+": HTML5 패턴 검증으로 숫자와 하이픈만 허용
- inputmode="numeric": 모바일에서 숫자 키패드 표시
- oninput="this.value = this.value.replace(/[^0-9-]/g, '')": 실시간으로 숫자와 하이픈 외 문자 제거