### PR TITLE
[BE] fix: 퇴사 직원 차감되도록 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/staff/list.html
+++ b/be/glossymatcha/templates/glossymatcha/staff/list.html
@@ -101,34 +101,24 @@
     <div class="col-md-4">
         <div class="card">
             <div class="card-body text-center">
-                <h5 class="text-primary">{{ staff_list|length }}</h5>
-                <small class="text-muted">전체 직원</small>
+                <h5 class="text-primary">{{ active_staff_count }}</h5>
+                <small class="text-muted">재직 중인 직원</small>
             </div>
         </div>
     </div>
     <div class="col-md-4">
         <div class="card">
             <div class="card-body text-center">
-                <h5 class="text-primary">
-                    {% regroup staff_list by employee_type as grouped_staff %}
-                    {% for group in grouped_staff %}
-                        {% if group.grouper == 'full_time' %}{{ group.list|length }}{% endif %}
-                    {% empty %}0{% endfor %}
-                </h5>
-                <small class="text-muted">정직원</small>
+                <h5 class="text-primary">{{ active_full_time_count }}</h5>
+                <small class="text-muted">재직 정직원</small>
             </div>
         </div>
     </div>
     <div class="col-md-4">
         <div class="card">
             <div class="card-body text-center">
-                <h5 class="text-success">
-                    {% regroup staff_list by employee_type as grouped_staff %}
-                    {% for group in grouped_staff %}
-                        {% if group.grouper == 'part_time' %}{{ group.list|length }}{% endif %}
-                    {% empty %}0{% endfor %}
-                </h5>
-                <small class="text-muted">파트타임</small>
+                <h5 class="text-success">{{ active_part_time_count }}</h5>
+                <small class="text-muted">재직 파트타임</small>
             </div>
         </div>
     </div>

--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -329,6 +329,26 @@ class StaffListView(LoginRequiredMixin, ListView):
     model = Staff
     template_name = 'glossymatcha/staff/list.html'
     context_object_name = 'staff_list'
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        staff_list = context['staff_list']
+        
+        # 재직 중인 직원만 필터링
+        active_staff = [staff for staff in staff_list if staff.is_active]
+        
+        # 재직 중인 직원 수 계산
+        active_staff_count = len(active_staff)
+        active_full_time_count = len([staff for staff in active_staff if staff.employee_type == 'full_time'])
+        active_part_time_count = len([staff for staff in active_staff if staff.employee_type == 'part_time'])
+        
+        context.update({
+            'active_staff_count': active_staff_count,
+            'active_full_time_count': active_full_time_count,
+            'active_part_time_count': active_part_time_count,
+        })
+        
+        return context
 
 class StaffCreateView(LoginRequiredMixin, CreateView):
     """


### PR DESCRIPTION
직원이 퇴사(resignation_date가 오늘 이전)로 변경되면 is_active 속성이 자동으로 False가 됨
재직 중인 직원 수, 재직 정직원 수, 재직 파트타임 수가 실시간으로 정확하게 표시됨
퇴사한 직원은 목록에는 여전히 보이지만 카운트에서는 제외됨