### PR TITLE
[FE] fix: 체험형 콘텐츠 ResultSection 수정

### DIFF
--- a/fe/src/components/GlossyPick/ResultSection.module.scss
+++ b/fe/src/components/GlossyPick/ResultSection.module.scss
@@ -67,9 +67,8 @@
             width: 100%;
             max-width: 200px;
             height: auto;
-            aspect-ratio: 150 / 240;
-            object-fit: contain;
-            margin-bottom: 0;
+            aspect-ratio: 150 / 200;
+            margin-bottom: 20px;
         }
 
         &__menuName {

--- a/fe/src/components/GlossyPick/ResultSection.module.scss
+++ b/fe/src/components/GlossyPick/ResultSection.module.scss
@@ -6,6 +6,8 @@
     flex-direction: column;
     align-items: center;
     margin-bottom: clamp(40px, 8vw, 100px);
+    width: 100vw;
+    max-width: 1280px;
 
     &__title {
         @include myeongjo(clamp(18px, 3vw, 28px), 500);

--- a/fe/src/components/GlossyPick/ResultSection.tsx
+++ b/fe/src/components/GlossyPick/ResultSection.tsx
@@ -45,7 +45,10 @@ export default function ResultSection({
                 </p>
             </section>
 
-            <div className={styles.result__actions}>
+            <div
+                className={styles.result__actions}
+                data-html2canvas-ignore="true"
+            >
                 <button onClick={onShare} className="btn-g">
                     공유하기
                 </button>


### PR DESCRIPTION
- `ResultSection`: 
  - image `object-fit: contain` -> `cover`로 변경
  - `width`, `max-width` 추가
  - `.result__actions`에 `data-html2canvas-ignore="true"` 속성 추가 (버튼 그룹을 캡쳐 이미지에서 제외)