### PR TITLE
[FE] fix: ios 환경 이미지 다운로드 개선

### DIFF
--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -69,11 +69,21 @@ export const useDownload = () => {
         async (elementId: string, fileName: string) => {
             const element = document.getElementById(elementId);
             if (!element) {
-                console.error("저장할 영역을 찾을 수 없습니다.");
+                alert("저장할 영역을 찾을 수 없습니다.");
                 return;
             }
 
             try {
+                // 로딩 상태 표시 (옵션)
+                const loadingElement = document.createElement("div");
+                loadingElement.innerHTML = "이미지 생성 중...";
+                loadingElement.style.cssText = `
+                    position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+                    background: rgba(0,0,0,0.8); color: white; padding: 20px;
+                    border-radius: 8px; z-index: 10000;
+                `;
+                document.body.appendChild(loadingElement);
+
                 const canvas = await html2canvas(element, {
                     scale: 2,
                     useCORS: true,
@@ -82,19 +92,92 @@ export const useDownload = () => {
 
                 const dataUrl = canvas.toDataURL("image/png");
 
+                // 로딩 제거
+                document.body.removeChild(loadingElement);
+
                 const isIOS =
                     /iPad|iPhone|iPod/.test(navigator.userAgent) ||
                     (navigator.userAgent.includes("Macintosh") &&
                         "ontouchend" in document);
 
                 if (isIOS) {
-                    const newWindow = window.open("", "_blank");
-                    if (newWindow) {
-                        newWindow.location.href = dataUrl;
-                    } else {
-                        console.warn("팝업이 차단되었습니다.");
+                    // iOS에서 확실하게 작동하는 방법
+                    try {
+                        // 방법 1: 즉시 새 창 열기 (사용자 클릭과 동기적으로 실행)
+                        const newWindow = window.open("about:blank", "_blank");
+
+                        if (newWindow) {
+                            // 새 창에 이미지 표시
+                            newWindow.document.write(`
+                                <html>
+                                    <head>
+                                        <title>${fileName}</title>
+                                        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                                        <style>
+                                            body { 
+                                                margin: 0; 
+                                                padding: 20px; 
+                                                text-align: center; 
+                                                background: #f5f5f5;
+                                            }
+                                            img { 
+                                                max-width: 100%; 
+                                                height: auto; 
+                                                border: 1px solid #ddd;
+                                                background: white;
+                                            }
+                                            .instructions {
+                                                margin-top: 20px;
+                                                padding: 15px;
+                                                background: white;
+                                                border-radius: 8px;
+                                                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+                                            }
+                                        </style>
+                                    </head>
+                                    <body>
+                                        <img src="${dataUrl}" alt="${fileName}" />
+                                        <div class="instructions">
+                                            <h3>이미지 저장 방법</h3>
+                                            <p>이미지를 길게 눌러서 "이미지 저장" 또는 "사진에 추가"를 선택하세요</p>
+                                        </div>
+                                    </body>
+                                </html>
+                            `);
+                            newWindow.document.close();
+                        } else {
+                            // 새 창이 차단된 경우 대안 방법
+                            throw new Error("팝업 차단");
+                        }
+                    } catch (popupError) {
+                        // 방법 2: 현재 창에서 다운로드 링크 생성
+                        const link = document.createElement("a");
+                        link.href = dataUrl;
+                        link.download = fileName;
+
+                        // iOS에서는 사용자 제스처 컨텍스트 확보를 위해 즉시 실행
+                        link.style.display = "none";
+                        document.body.appendChild(link);
+
+                        // iOS에서는 click() 대신 실제 사용자 이벤트 시뮬레이션
+                        const clickEvent = new MouseEvent("click", {
+                            view: window,
+                            bubbles: true,
+                            cancelable: false,
+                        });
+                        link.dispatchEvent(clickEvent);
+
+                        document.body.removeChild(link);
+
+                        // 사용자에게 안내 메시지
+                        setTimeout(() => {
+                            alert(
+                                "iOS에서 이미지를 저장하려면:\n1. 생성된 이미지를 길게 누르세요\n2. '이미지 저장' 또는 '사진에 추가'를 선택하세요"
+                            );
+                        }, 500);
                     }
                 } else {
+                    // PC/Android 기존 방식
                     const link = document.createElement("a");
                     link.href = dataUrl;
                     link.download = fileName;
@@ -104,6 +187,7 @@ export const useDownload = () => {
                 }
             } catch (e) {
                 console.error("이미지 저장 실패:", e);
+                alert("이미지 저장에 실패했습니다. 다시 시도해주세요.");
             }
         },
         []


### PR DESCRIPTION
- 즉시 새 창 열기: `html2canvas` 처리 전 `window.open("about:blank")`로 팝업 차단 방지
- 사용자 제스처 컨텍스트 유지: 클릭 이벤트와 동기적으로 실행되도록 개선
- 새 창 차단 시 현재 창에서 다운로드 링크 실행