### PR TITLE
[BE] fix: suppliers email 눌렀을 때 Gmail로 답장하게 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/suppliers/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/suppliers/detail.html
@@ -58,7 +58,7 @@
                     <tr>
                         <td class="text-muted">이메일</td>
                         <td>
-                            <a href="mailto:{{ supplier.email }}" class="text-decoration-none">
+                            <a href="https://mail.google.com/mail/?view=cm&fs=1&to={{ supplier.email }}" target="_blank" class="text-decoration-none">
                                 {{ supplier.email }}
                             </a>
                         </td>


### PR DESCRIPTION
 - mailto:{{ supplier.email }} → https://mail.google.com/mail/?view=cm&fs=1&to={{ supplier.email }}        
  - target="_blank" 속성 추가로 새 탭에서 열림