### PR TITLE
[FE] fix: useDownload IOS 환경 수정

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "html2canvas": "^1.4.1",
+        "jspdf": "^3.0.1",
         "next": "15.4.4",
         "next-intl": "^4.3.4",
         "react": "19.1.0",
@@ -24,6 +25,15 @@
         "eslint": "^9",
         "eslint-config-next": "15.4.4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1329,6 +1339,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -1348,6 +1365,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.38.0",
@@ -2156,6 +2180,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2230,6 +2266,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/call-bind": {
@@ -2311,6 +2359,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2410,6 +2478,18 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz",
+      "integrity": "sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2591,6 +2671,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -3291,6 +3381,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4217,6 +4313,24 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jspdf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4744,6 +4858,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4854,6 +4975,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -4931,6 +5062,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5002,6 +5140,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/run-parallel": {
@@ -5339,6 +5487,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5536,6 +5694,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/text-segmentation": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "html2canvas": "^1.4.1",
+    "jspdf": "^3.0.1",
     "next": "15.4.4",
     "next-intl": "^4.3.4",
     "react": "19.1.0",

--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -1,70 +1,8 @@
 import { useCallback } from "react";
 import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
 
-/**
- * DOM 요소를 캡처하여 이미지로 다운로드하는 기능을 제공하는 React 훅
- *
- * @description
- * 이 훅은 html2canvas 라이브러리를 사용하여 웹 페이지의 특정 DOM 요소를
- * 고해상도 PNG 이미지로 캡처하고 다운로드하는 기능을 제공합니다.
- *
- * **플랫폼별 동작:**
- * - **데스크톱/Android**: 브라우저의 기본 다운로드 기능을 사용하여 파일 자동 저장
- * - **iOS (iPhone/iPad)**: 새 탭에서 이미지를 열어 사용자가 수동으로 저장 (길게 눌러 저장)
- *
- * **특징:**
- * - 고해상도 캡처 (scale: 2)
- * - CORS 지원으로 외부 이미지 처리 가능
- * - iOS 13+ iPad의 Safari User Agent 위장 감지 지원
- * - 팝업 차단 상황에 대한 에러 처리
- *
- * @requires html2canvas - DOM을 캔버스로 변환하는 라이브러리
- *
- * @returns {Object} 이미지 다운로드 기능이 포함된 객체
- * @returns {Function} returns.downloadImage - 이미지 다운로드 함수
- *
- * @since 1.0.0
- * @author Your Name
- */
 export const useDownload = () => {
-    /**
-     * 지정된 DOM 요소를 캡처하여 PNG 이미지로 다운로드
-     *
-     * @async
-     * @function downloadImage
-     *
-     * @param {string} elementId - 캡처할 DOM 요소의 ID 속성값
-     * @param {string} fileName - 저장할 파일명 (확장자 포함, 예: "image.png")
-     *
-     * @description
-     * 이 함수는 다음과 같은 순서로 동작합니다:
-     * 1. 지정된 ID의 DOM 요소 검색
-     * 2. html2canvas를 사용하여 요소를 캔버스로 변환
-     * 3. 캔버스를 PNG 데이터 URL로 변환
-     * 4. 플랫폼에 따라 적절한 저장 방식 적용
-     *
-     * **html2canvas 옵션:**
-     * - `scale: 2`: 레티나 디스플레이 대응 고해상도
-     * - `useCORS: true`: 외부 도메인 이미지 처리 허용
-     * - `allowTaint: false`: 보안을 위한 tainted 캔버스 방지
-     *
-     * **iOS 감지 로직:**
-     * - iPhone/iPad/iPod User Agent 패턴 매칭
-     * - iOS 13+ iPad Safari의 데스크톱 User Agent 위장 감지
-     *   (Macintosh + ontouchend 지원으로 판별)
-     *
-     * **에러 처리:**
-     * - DOM 요소 미존재 시 콘솔 에러 출력 후 early return
-     * - html2canvas 처리 실패 시 콘솔 에러 출력
-     * - iOS 팝업 차단 시 경고 메시지 출력
-     *
-     * @throws {Error} html2canvas 라이브러리 처리 중 발생하는 에러
-     *
-     * @see {@link https://html2canvas.hertzen.com/} html2canvas 공식 문서
-     * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL} Canvas.toDataURL API
-     *
-     * @since 1.0.0
-     */
     const downloadImage = useCallback(
         async (elementId: string, fileName: string) => {
             const element = document.getElementById(elementId);
@@ -73,6 +11,11 @@ export const useDownload = () => {
                 return;
             }
 
+            const isIOS =
+                /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+                (navigator.userAgent.includes("Macintosh") &&
+                    "ontouchend" in document);
+
             try {
                 const canvas = await html2canvas(element, {
                     scale: 2,
@@ -80,24 +23,52 @@ export const useDownload = () => {
                     allowTaint: false,
                 });
 
-                const dataUrl = canvas.toDataURL("image/png");
-
-                const isIOS =
-                    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-                    (navigator.userAgent.includes("Macintosh") &&
-                        "ontouchend" in document);
-
                 if (isIOS) {
-                    const newWindow = window.open("", "_blank");
-                    if (newWindow) {
-                        newWindow.location.href = dataUrl;
-                    } else {
-                        console.warn("팝업이 차단되었습니다.");
+                    // PDF 변환
+                    const imgData = canvas.toDataURL("image/png");
+                    const pdf = new jsPDF("p", "mm", "a4");
+                    const imgWidth = 210;
+                    const pageHeight = 295;
+                    const imgHeight =
+                        (canvas.height * imgWidth) / canvas.width;
+                    let heightLeft = imgHeight;
+                    let position = 0;
+
+                    pdf.addImage(
+                        imgData,
+                        "PNG",
+                        0,
+                        position,
+                        imgWidth,
+                        imgHeight,
+                        undefined,
+                        "FAST"
+                    );
+                    heightLeft -= pageHeight;
+
+                    while (heightLeft >= 0) {
+                        position = heightLeft - imgHeight;
+                        pdf.addPage();
+                        pdf.addImage(
+                            imgData,
+                            "PNG",
+                            0,
+                            position,
+                            imgWidth,
+                            imgHeight,
+                            undefined,
+                            "FAST"
+                        );
+                        heightLeft -= pageHeight;
                     }
+
+                    pdf.save(`${fileName}.pdf`);
                 } else {
+                    // PNG 다운로드
+                    const dataUrl = canvas.toDataURL("image/png");
                     const link = document.createElement("a");
                     link.href = dataUrl;
-                    link.download = fileName;
+                    link.download = `${fileName}.png`;
                     document.body.appendChild(link);
                     link.click();
                     document.body.removeChild(link);

--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -2,7 +2,30 @@ import { useCallback } from "react";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
 
+/**
+ * DOM 요소를 이미지 또는 PDF로 다운로드하는 기능을 제공하는 커스텀 훅
+ * iOS 디바이스에서는 PDF로, 다른 디바이스에서는 PNG 이미지로 저장됩니다.
+ *
+ * @returns {Object} downloadImage 함수가 포함된 객체
+ */
 export const useDownload = () => {
+    /**
+     * 지정된 DOM 요소를 캡처하여 이미지 또는 PDF 파일로 다운로드합니다.
+     * iOS 디바이스에서는 PDF 형식으로, 다른 디바이스에서는 PNG 이미지로 저장됩니다.
+     *
+     * @param {string} elementId - 캡처할 DOM 요소의 ID
+     * @param {string} fileName - 저장될 파일의 이름 (확장자 제외)
+     * @returns {Promise<void>} 비동기 함수로 완료 시 Promise를 반환합니다.
+     *
+     * @example
+     * ```tsx
+     * const { downloadImage } = useDownload();
+     *
+     * const handleDownload = () => {
+     *   downloadImage('chart-container', 'my-chart');
+     * };
+     * ```
+     */
     const downloadImage = useCallback(
         async (elementId: string, fileName: string) => {
             const element = document.getElementById(elementId);
@@ -11,29 +34,32 @@ export const useDownload = () => {
                 return;
             }
 
+            // iOS 디바이스 감지 (iPad, iPhone, iPod 또는 터치 지원 MacOS)
             const isIOS =
                 /iPad|iPhone|iPod/.test(navigator.userAgent) ||
                 (navigator.userAgent.includes("Macintosh") &&
                     "ontouchend" in document);
 
             try {
+                // html2canvas를 사용하여 DOM 요소를 캔버스로 변환
                 const canvas = await html2canvas(element, {
-                    scale: 2,
-                    useCORS: true,
-                    allowTaint: false,
+                    scale: 2, // 고해상도를 위한 스케일링
+                    useCORS: true, // 외부 리소스 허용
+                    allowTaint: false, // 오염된 캔버스 방지
                 });
 
                 if (isIOS) {
-                    // PDF 변환
+                    // iOS 디바이스: PDF로 저장
                     const imgData = canvas.toDataURL("image/png");
                     const pdf = new jsPDF("p", "mm", "a4");
-                    const imgWidth = 210;
-                    const pageHeight = 295;
+                    const imgWidth = 210; // A4 용지 너비 (mm)
+                    const pageHeight = 295; // A4 용지 높이 (mm)
                     const imgHeight =
                         (canvas.height * imgWidth) / canvas.width;
                     let heightLeft = imgHeight;
                     let position = 0;
 
+                    // 첫 번째 페이지에 이미지 추가
                     pdf.addImage(
                         imgData,
                         "PNG",
@@ -46,6 +72,7 @@ export const useDownload = () => {
                     );
                     heightLeft -= pageHeight;
 
+                    // 이미지가 한 페이지를 초과하는 경우 추가 페이지 생성
                     while (heightLeft >= 0) {
                         position = heightLeft - imgHeight;
                         pdf.addPage();
@@ -64,7 +91,7 @@ export const useDownload = () => {
 
                     pdf.save(`${fileName}.pdf`);
                 } else {
-                    // PNG 다운로드
+                    // 다른 디바이스: PNG 이미지로 저장
                     const dataUrl = canvas.toDataURL("image/png");
                     const link = document.createElement("a");
                     link.href = dataUrl;


### PR DESCRIPTION
- `useDownload` 훅에서 iOS 환경 감지 로직(isIOS) 추가
- `npm install jspdf`
- iOS Safari의 <a download> 미지원 및 팝업 차단 문제를 해결하기 위해 PDF 저장 방식으로 우회
- 비 iOS 환경(PC/안드로이드)은 기존 PNG 다운로드 방식 유지