### PR TITLE
[FE] fix: iOS Safari PDF 다운로드 이슈 해결을 위한 폴백 시스템 구현

### DIFF
--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -49,7 +49,7 @@ export const useDownload = () => {
                 });
 
                 if (isIOS) {
-                    // iOS 디바이스: PDF로 저장
+                    // iOS 디바이스: PDF로 저장 (여러 방법 시도)
                     const imgData = canvas.toDataURL("image/png");
                     const pdf = new jsPDF("p", "mm", "a4");
                     const imgWidth = 210; // A4 용지 너비 (mm)
@@ -89,7 +89,63 @@ export const useDownload = () => {
                         heightLeft -= pageHeight;
                     }
 
-                    pdf.save(`${fileName}.pdf`);
+                    // iOS Safari에서 다운로드가 작동하지 않는 문제 해결을 위한 다중 방법 시도
+                    try {
+                        // 방법 1: 표준 save() 시도
+                        pdf.save(`${fileName}.pdf`);
+                    } catch (saveError) {
+                        console.warn(
+                            "표준 save() 실패, 대안 방법 시도:",
+                            saveError
+                        );
+
+                        try {
+                            // 방법 2: Blob을 이용한 다운로드
+                            const pdfBlob = pdf.output("blob");
+                            const blobUrl = URL.createObjectURL(pdfBlob);
+                            const link = document.createElement("a");
+                            link.href = blobUrl;
+                            link.download = `${fileName}.pdf`;
+                            link.style.display = "none";
+                            document.body.appendChild(link);
+                            link.click();
+                            document.body.removeChild(link);
+
+                            // URL 객체 정리
+                            setTimeout(
+                                () => URL.revokeObjectURL(blobUrl),
+                                100
+                            );
+                        } catch (blobError) {
+                            console.warn(
+                                "Blob 방법 실패, 새 탭으로 열기 시도:",
+                                blobError
+                            );
+
+                            // 방법 3: 새 탭에서 PDF 열기 (사용자가 수동으로 저장해야 함)
+                            const pdfDataUri = pdf.output("datauristring");
+                            const newTab = window.open();
+                            if (newTab) {
+                                newTab.document.write(`
+                                    <html>
+                                        <head><title>${fileName}.pdf</title></head>
+                                        <body style="margin:0;">
+                                            <iframe src="${pdfDataUri}" style="width:100%;height:100vh;border:none;"></iframe>
+                                            <div style="position:fixed;top:10px;left:10px;background:rgba(0,0,0,0.8);color:white;padding:10px;border-radius:5px;font-family:sans-serif;">
+                                                PDF가 생성되었습니다. 공유 버튼을 눌러 저장하세요.
+                                            </div>
+                                        </body>
+                                    </html>
+                                `);
+                                newTab.document.close();
+                            } else {
+                                // 팝업이 차단된 경우
+                                alert(
+                                    "팝업이 차단되었습니다. 팝업을 허용하고 다시 시도해주세요."
+                                );
+                            }
+                        }
+                    }
                 } else {
                     // 다른 디바이스: PNG 이미지로 저장
                     const dataUrl = canvas.toDataURL("image/png");


### PR DESCRIPTION
## 📱 iOS Safari PDF 다운로드 이슈 해결

### 🐛 문제
- iOS Safari에서 jsPDF의 `save()` 메서드가 작동하지 않는 문제
- 아이폰에서 PDF 다운로드 버튼 클릭 시 반응 없음

### 🔧 해결 방법
iOS Safari의 제약사항을 고려한 **3단계 폴백 시스템** 구현:

1. **1단계**: 기존 `pdf.save()` 메서드 시도
2. **2단계**: Blob + `URL.createObjectURL()` 방식으로 다운로드 시도
3. **3단계**: 새 탭에서 PDF를 열어 사용자가 수동으로 저장하도록 안내
