### PR TITLE
[FE] 홈 문제 해결 시도

### DIFF
--- a/fe/src/app/page.tsx
+++ b/fe/src/app/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import styles from "./Home.module.scss";
-import { useEffect, useRef, useState } from "react";
-import SideInfo from "@/components/Home/SideInfo/SideInfo";
-import ImageSection from "@/components/Home/ImageSection/ImageSection";
+import dynamic from "next/dynamic";
 import { useMobileDetect } from "@/hooks/useMobileDetect";
-import MobileHome from "@/components/Home/MobileHome/MobileHome";
-import PcHome from "@/components/Home/PcHome/PcHome";
+
+const PcHome = dynamic(() => import("@/components/Home/PcHome/PcHome"), {
+  ssr: false,
+});
+const MobileHome = dynamic(
+  () => import("@/components/Home/MobileHome/MobileHome"),
+  { ssr: false }
+);
 
 export interface HomeContent {
   title: string;
@@ -65,9 +68,7 @@ const homeContents: HomeContent[] = [
 
 export default function Home() {
   const isMobile = useMobileDetect();
-
-  // mobile에서 순간적으로 pc가 보이는 문제 해결
-  // if (isMobile === null) return null;
+  if (isMobile === null) return null;
 
   return (
     <>

--- a/fe/src/components/Home/MobileHome/MobileHome.module.scss
+++ b/fe/src/components/Home/MobileHome/MobileHome.module.scss
@@ -2,10 +2,10 @@
 @use "../../../styles/mixins.scss" as *;
 
 .mobile-container {
-  scroll-snap-type: y mandatory;
-  overflow-y: scroll;
-  -webkit-overflow-scrolling: touch;
-  height: 100vh;
+  // scroll-snap-type: y mandatory;
+  // overflow-y: scroll;
+  // -webkit-overflow-scrolling: touch;
+  // height: 100vh;
 }
 
 /* common */


### PR DESCRIPTION
- 홈화면 초기 랜더링 개선 시도
- 모바일버전 한 섹션에서 스크롤 조금만 내려도 다음 섹션에 딱 맞게 넘어가게 하기 => 해당 기능을 추가하면 Footer에서 자꾸 문제 발생해서 일단 주석처리