### PR TITLE
[BE] fix: 급여 기록 입력 저장하기 후 출력 페이지 대시보드에서 해당 직원 페이지로 이동하게끔 수정

### DIFF
--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -430,7 +430,9 @@ class WorkRecordCreateView(LoginRequiredMixin, CreateView):
     model = WorkRecord
     form_class = WorkRecordForm
     template_name = 'glossymatcha/staff/work_record.html'
-    success_url = reverse_lazy('dashboard')
+
+    def get_success_url(self):
+        return reverse_lazy('staff_detail', kwargs={'pk': self.object.staff.pk})
 
     def get_initial(self):
         initial = super().get_initial()


### PR DESCRIPTION
## 변경 사항
- WorkRecordCreateView에서 고정된 success_url = reverse_lazy('dashboard')를 제거
- get_success_url() 메소드를 추가하여 동적으로 저장된 급여 기록의 직원 상세 페이지(staff_detail)로 이동하도록 설정