### PR TITLE
[BE] fix: 최근 급여 기록 삭제 추가 구현

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/staff/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/staff/detail.html
@@ -131,9 +131,14 @@
                         <i class="bi bi-plus-circle me-2"></i>급여 기록 입력
                     </button>
                     {% if recent_work_records %}
-                        <a href="{% url 'work_record_update' recent_work_records.0.pk %}" class="btn btn-outline-secondary btn-sm">
-                            <i class="bi bi-pencil me-2"></i>최근 기록 수정
-                        </a>
+                        <div class="btn-group w-100">
+                            <a href="{% url 'work_record_update' recent_work_records.0.pk %}" class="btn btn-outline-secondary btn-sm">
+                                <i class="bi bi-pencil me-2"></i>최근 기록 수정
+                            </a>
+                            <a href="{% url 'work_record_delete' recent_work_records.0.pk %}" class="btn btn-outline-danger btn-sm">
+                                <i class="bi bi-trash"></i>
+                            </a>
+                        </div>
                     {% endif %}
                 </div>
             </div>
@@ -219,9 +224,14 @@
                                 <small class="text-muted">{{ record.created_at|date:"m.d H:i" }}</small>
                             </td>
                             <td>
-                                <a href="{% url 'work_record_update' record.pk %}" class="btn btn-sm btn-outline-primary">
-                                    <i class="bi bi-pencil"></i>
-                                </a>
+                                <div class="btn-group">
+                                    <a href="{% url 'work_record_update' record.pk %}" class="btn btn-sm btn-outline-primary">
+                                        <i class="bi bi-pencil"></i>
+                                    </a>
+                                    <a href="{% url 'work_record_delete' record.pk %}" class="btn btn-sm btn-outline-danger">
+                                        <i class="bi bi-trash"></i>
+                                    </a>
+                                </div>
                             </td>
                         </tr>
                         {% endfor %}

--- a/be/glossymatcha/templates/glossymatcha/staff/work_record_delete.html
+++ b/be/glossymatcha/templates/glossymatcha/staff/work_record_delete.html
@@ -1,0 +1,78 @@
+{% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
+
+{% block title %}급여 기록 삭제 - Glossy Matcha{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header bg-danger text-white">
+                <h5 class="mb-0">
+                    <i class="bi bi-trash me-2"></i>급여 기록 삭제
+                </h5>
+            </div>
+            <div class="card-body">
+                <div class="alert alert-warning">
+                    <i class="bi bi-exclamation-triangle me-2"></i>
+                    <strong>주의:</strong> 이 작업은 되돌릴 수 없습니다.
+                </div>
+                
+                <h6>삭제할 급여 기록 정보:</h6>
+                <div class="card bg-light">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-sm-4"><strong>직원:</strong></div>
+                            <div class="col-sm-8">{{ staff.name }}{% if staff.nickname %} ({{ staff.nickname }}){% endif %}</div>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-4"><strong>총 근무시간:</strong></div>
+                            <div class="col-sm-8">{{ object.total_hours }}시간</div>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-4"><strong>시급:</strong></div>
+                            <div class="col-sm-8">{{ object.hourly_rate|korean_won_with_unit }}</div>
+                        </div>
+                        {% if object.monthly_salary %}
+                        <div class="row">
+                            <div class="col-sm-4"><strong>월급:</strong></div>
+                            <div class="col-sm-8">{{ object.monthly_salary|korean_won_with_unit }}</div>
+                        </div>
+                        {% endif %}
+                        {% if object.weekly_holiday_allowance %}
+                        <div class="row">
+                            <div class="col-sm-4"><strong>주휴수당:</strong></div>
+                            <div class="col-sm-8">{{ object.weekly_holiday_allowance|korean_won_with_unit }}</div>
+                        </div>
+                        {% endif %}
+                        <div class="row">
+                            <div class="col-sm-4"><strong>지급합계:</strong></div>
+                            <div class="col-sm-8"><strong class="text-success">{{ object.total_payment|korean_won_with_unit }}</strong></div>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-4"><strong>등록일:</strong></div>
+                            <div class="col-sm-8">{{ object.created_at|date:"Y년 m월 d일 H:i" }}</div>
+                        </div>
+                    </div>
+                </div>
+                
+                <p class="mt-3 mb-4">
+                    <strong>{{ staff.name }}{% if staff.nickname %} ({{ staff.nickname }}){% endif %}</strong> 직원의 위 급여 기록을 정말 삭제하시겠습니까?
+                </p>
+                
+                <form method="post">
+                    {% csrf_token %}
+                    <div class="d-flex justify-content-between">
+                        <a href="{% url 'staff_detail' staff.pk %}" class="btn btn-secondary">
+                            <i class="bi bi-arrow-left me-2"></i>취소
+                        </a>
+                        <button type="submit" class="btn btn-danger">
+                            <i class="bi bi-trash me-2"></i>삭제하기
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/be/glossymatcha/urls.py
+++ b/be/glossymatcha/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('staff/<int:pk>/delete/', views.StaffDeleteView.as_view(), name='staff_delete'),       # 직원 삭제
     path('work-record/create/', views.WorkRecordCreateView.as_view(), name='work_record_create'), # 근무시간 입력
     path('work-record/<int:pk>/update/', views.WorkRecordUpdateView.as_view(), name='work_record_update'), # 근무기록 수정
+    path('work-record/<int:pk>/delete/', views.WorkRecordDeleteView.as_view(), name='work_record_delete'), # 근무기록 삭제
 
     # Django Template Views for suppliers management
     path('suppliers/', views.SuppliersListView.as_view(), name='suppliers_list'),               # 거래처 목록

--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -485,6 +485,29 @@ class WorkRecordUpdateView(LoginRequiredMixin, UpdateView):
         response = super().form_valid(form)
         messages.success(self.request, f'{self.object.staff.name}의 근무 기록이 수정되었습니다.')
         return response
+
+class WorkRecordDeleteView(LoginRequiredMixin, DeleteView):
+    """
+    직원 근무 기록 삭제 페이지
+    - 로그인한 사용자만 접근 가능
+    - Django Template을 사용하여 근무 기록 삭제 페이지를 렌더링
+    """
+    model = WorkRecord
+    template_name = 'glossymatcha/staff/work_record_delete.html'
+
+    def get_success_url(self):
+        return reverse_lazy('staff_detail', kwargs={'pk': self.object.staff.pk})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['staff'] = self.object.staff
+        return context
+
+    def delete(self, request, *args, **kwargs):
+        staff_name = self.get_object().staff.name
+        response = super().delete(request, *args, **kwargs)
+        messages.success(request, f'{staff_name}의 근무 기록이 삭제되었습니다.')
+        return response
     
 # Django Template Views for suppliers management
 class SuppliersListView(LoginRequiredMixin, ListView):


### PR DESCRIPTION
1. WorkRecordDeleteView - 급여 기록 삭제를 위한 뷰 클래스
2. URL 경로 
- ```/work-record/<int:pk>/delete/```로 급여 기록 삭제 페이지 접근       
3. 삭제 확인 템플릿
- work_record_delete.html 생성하여 삭제 전 확인 페이지 제공
4. 직원 상세 페이지 개선:
 - 급여 정보 카드에서 "최근 기록 수정"과 삭제 버튼을 버튼 그룹으로 배치
 - 최근 급여 기록 테이블에서 각 기록별로 수정/삭제 버튼을 버튼 그룹으로 배치