### PR TITLE
[FE] fix: useDownload iOS 환경 수정

### DIFF
--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -40,27 +40,27 @@ export default function MatchaGenerator() {
     const handleDownload = () => {
         if (!recommendation) return;
 
-        // iOS 여부 체크
         const isIOS =
             /iPad|iPhone|iPod/.test(navigator.userAgent) &&
             !(window as unknown as { MSStream?: unknown }).MSStream;
 
         if (isIOS) {
-            // iOS는 빈 새창을 먼저 열어줌
+            // iOS는 클릭 이벤트 핸들러에서 즉시 새 탭 열기 (팝업 차단 방지)
             const newWindow = window.open("", "_blank");
-            if (newWindow) {
-                downloadImage(
-                    "result-section",
-                    `${menuData[recommendation].name}.png`,
-                    newWindow
-                );
-            } else {
+            if (!newWindow) {
                 alert(
-                    "새 창 열기가 차단되었습니다. 팝업 차단 해제 후 다시 시도해주세요."
+                    "팝업 차단이 되어 새 탭을 열 수 없습니다. 팝업 허용 후 다시 시도해주세요."
                 );
+                return;
             }
+            // 새 탭 객체 넘겨서 이미지 렌더링 처리
+            downloadImage(
+                "result-section",
+                `${menuData[recommendation].name}.png`,
+                newWindow
+            );
         } else {
-            // iOS 아니면 그냥 다운로드 실행
+            // iOS 외는 그냥 다운로드 처리 (새 탭 없이)
             downloadImage(
                 "result-section",
                 `${menuData[recommendation].name}.png`

--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -10,20 +10,33 @@ export const useDownload = () => {
         ) => {
             const element = document.getElementById(elementId);
             if (!element) {
-                console.error("저장할 영역을 찾을 수 없습니다.");
+                alert("저장할 영역을 찾을 수 없습니다.");
+                if (newWindow) newWindow.close();
                 return;
             }
 
             try {
-                const canvas = await html2canvas(element, { scale: 2 });
+                const canvas = await html2canvas(element, {
+                    scale: 2,
+                    useCORS: true,
+                    allowTaint: false,
+                });
                 const dataUrl = canvas.toDataURL("image/png");
 
                 if (newWindow) {
-                    newWindow.document.write(
-                        `<img src="${dataUrl}" alt="${fileName}" />`
-                    );
-                    newWindow.document.title = fileName;
+                    // 새 탭이 열려있으면 이미지 보여주기
+                    newWindow.document.body.innerHTML = `
+                        <img src="${dataUrl}" alt="${fileName}" style="max-width:100%; height:auto; display:block; margin:auto;" />
+                    `;
+
+                    if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+                        newWindow.document.body.insertAdjacentHTML(
+                            "beforeend",
+                            `<p style="text-align:center; font-family:sans-serif; margin-top:1rem;">이미지를 길게 눌러 저장하세요.</p>`
+                        );
+                    }
                 } else {
+                    // 새 탭 없이 바로 다운로드 링크 생성
                     const link = document.createElement("a");
                     link.href = dataUrl;
                     link.download = fileName;
@@ -31,8 +44,14 @@ export const useDownload = () => {
                     link.click();
                     document.body.removeChild(link);
                 }
-            } catch (e) {
-                console.error("이미지 저장 실패:", e);
+            } catch (error) {
+                console.error("이미지 저장 실패", error);
+                if (newWindow) {
+                    newWindow.document.body.innerHTML =
+                        "<p style='color:red;'>이미지 생성 실패</p>";
+                } else {
+                    alert("이미지 저장에 실패했습니다.");
+                }
             }
         },
         []


### PR DESCRIPTION
- iOS 기기에서 이미지 다운로드 시 팝업 차단 방지용 새 탭 열기 기능 추가 및 isIOS 체크 함수 분리
- 기존 다운로드 훅(useDownload)은 새 탭이 열려 있을 경우 이미지 렌더링, 그렇지 않을 경우 바로 다운로드 처리하도록 수정.
- PC 및 Android 환경은 기존과 동일하게 새 탭 없이 바로 다운로드.