### PR TITLE
[BE] fix: 퇴사 처리 된 직원은 근무형태가 자동으로 퇴사로 바뀌게 수정

### DIFF
--- a/be/glossymatcha/forms.py
+++ b/be/glossymatcha/forms.py
@@ -70,6 +70,20 @@ class StaffForm(forms.ModelForm):
             return resident_digits
         return resident_number
 
+    def clean(self):
+        cleaned_data = super().clean()
+        resignation_date = cleaned_data.get('resignation_date')
+        employee_type = cleaned_data.get('employee_type')
+        
+        # 퇴사일이 설정되면 자동으로 근무형태를 '퇴사'로 변경
+        if resignation_date and employee_type != 'resigned':
+            cleaned_data['employee_type'] = 'resigned'
+        # 퇴사일이 없는데 근무형태가 '퇴사'이면 정직원으로 변경
+        elif not resignation_date and employee_type == 'resigned':
+            cleaned_data['employee_type'] = 'full_time'
+            
+        return cleaned_data
+
 class WorkRecordForm(forms.ModelForm):
     class Meta:
         model = WorkRecord

--- a/be/glossymatcha/models.py
+++ b/be/glossymatcha/models.py
@@ -136,6 +136,7 @@ class Staff(models.Model):
     EMPLOYEE_TYPE_CHOICES = [
         ('full_time', '정직원'),
         ('part_time', '파트타임'),
+        ('resigned', '퇴사'),
     ]
     
     name = models.CharField(max_length=50, verbose_name="직원명")
@@ -180,6 +181,12 @@ class Staff(models.Model):
     
     def save(self, *args, **kwargs):
         self.clean()
+        # 퇴사일이 설정되면 근무형태를 '퇴사'로 변경
+        if self.resignation_date and self.employee_type != 'resigned':
+            self.employee_type = 'resigned'
+        # 퇴사일이 제거되면 기본값으로 정직원으로 변경
+        elif not self.resignation_date and self.employee_type == 'resigned':
+            self.employee_type = 'full_time'  # 또는 원래 근무형태를 복원하는 로직
         super().save(*args, **kwargs)
     
     def __str__(self):

--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -345,11 +345,12 @@ class StaffListView(LoginRequiredMixin, ListView):
                 default=models.Value(1),  # 퇴사
                 output_field=models.IntegerField(),
             ),
-            # 직종 정렬 우선순위: 정직원 > 파트직원
+            # 직종 정렬 우선순위: 정직원 > 파트직원 > 퇴사
             employee_type_order=models.Case(
                 models.When(employee_type='full_time', then=models.Value(0)),  # 정직원
                 models.When(employee_type='part_time', then=models.Value(1)),   # 파트직원
-                default=models.Value(2),
+                models.When(employee_type='resigned', then=models.Value(2)),    # 퇴사
+                default=models.Value(3),
                 output_field=models.IntegerField(),
             )
         ).order_by('status_order', 'employee_type_order', 'hire_date')


### PR DESCRIPTION
1. Staff 모델 수정:
    - EMPLOYEE_TYPE_CHOICES에 ('resigned', '퇴사') 옵션 추가
    - save() 메소드에서 퇴사일이 설정되면 자동으로 employee_type을 'resigned'로 변경
    - 퇴사일이 제거되면 자동으로 'full_time'으로 복원
2. StaffForm 수정:
    - clean() 메소드 추가하여 폼에서도 퇴사일과 근무형태를 연동
3. StaffListView 정렬 수정:
    - 정렬 순서에 퇴사(resigned) 타입 추가
    - 정직원 → 파트직원 → 퇴사 순으로 정렬