### PR TITLE
[FE] fix: iOS 새 탭 이미지 렌더링 중복 코드 리팩토링 및 로딩 처리 개선

### DIFF
--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -24,7 +24,6 @@ export const useDownload = () => {
                 const dataUrl = canvas.toDataURL("image/png");
 
                 if (newWindow) {
-                    // 새 탭에 기본 HTML과 로딩 메시지 먼저 작성
                     newWindow.document.write(`
                         <html>
                             <head><title>${fileName}</title></head>
@@ -35,8 +34,7 @@ export const useDownload = () => {
                     `);
                     newWindow.document.close();
 
-                    // 약간의 딜레이 후 이미지 삽입
-                    setTimeout(() => {
+                    const insertImage = () => {
                         if (newWindow.closed) return;
                         try {
                             newWindow.document.body.innerHTML = `
@@ -46,7 +44,11 @@ export const useDownload = () => {
                             newWindow.document.body.innerHTML =
                                 "<p style='color:red;'>이미지 생성 실패</p>";
                         }
-                    }, 500); // 500ms 딜레이
+                    };
+
+                    newWindow.onload = insertImage;
+
+                    setTimeout(insertImage, 1500);
                 } else {
                     // 새 탭 없이 바로 다운로드 링크 생성
                     const link = document.createElement("a");


### PR DESCRIPTION
- 새 탭에 이미지 삽입하는 코드를 insertImage 함수로 분리하여 중복 제거
- 새 탭 문서 로딩 완료 이벤트(onload)와 setTimeout 콜백에서 모두 insertImage를 호출하도록 변경
- 새 탭에 로딩 메시지를 표시한 뒤 이미지가 안정적으로 나타나도록 처리하여 사용자 경험 개선