### PR TITLE
[BE] fix: 콤마 포맷팅 빠진부분 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/daily_sales/delete.html
+++ b/be/glossymatcha/templates/glossymatcha/daily_sales/delete.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}일별 매출 삭제{% endblock %}
 
@@ -23,9 +24,9 @@
                         <strong style="color: #373735;">매출 정보:</strong>
                         <ul class="list-unstyled mt-2" style="color: #373735;">
                             <li><strong>날짜:</strong> {{ object.date }}</li>
-                            <li><strong>총 매출:</strong> {{ object.total_sales|floatformat:0 }}원</li>
-                            <li><strong>현금 매출:</strong> {{ object.cash_sales|floatformat:0 }}원</li>
-                            <li><strong>카드 매출:</strong> {{ object.card_sales|floatformat:0 }}원</li>
+                            <li><strong>총 매출:</strong> {{ object.total_sales|korean_won_with_unit }}</li>
+                            <li><strong>현금 매출:</strong> {{ object.cash_sales|korean_won_with_unit }}</li>
+                            <li><strong>카드 매출:</strong> {{ object.card_sales|korean_won_with_unit }}</li>
                         </ul>
                     </div>
                     

--- a/be/glossymatcha/templates/glossymatcha/daily_sales/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/daily_sales/detail.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}{{ daily_sale.date }} 일별 매출 상세 - Glossy Matcha{% endblock %}
 
@@ -51,7 +52,7 @@
                         <div class="card bg-brand-beige">
                             <div class="card-body text-center">
                                 <h6 style="color: #00563f;">오프라인 매출</h6>
-                                <h4 style="color: #00563f;">{{ daily_sale.offline_sales|floatformat:0 }}원</h4>
+                                <h4 style="color: #00563f;">{{ daily_sale.offline_sales|korean_won_with_unit }}</h4>
                             </div>
                         </div>
                     </div>
@@ -59,7 +60,7 @@
                         <div class="card bg-brand-green-light">
                             <div class="card-body text-center">
                                 <h6 style="color: #373735;">기타 매출</h6>
-                                <h4 style="color: #373735;">{{ daily_sale.other_sales|floatformat:0 }}원</h4>
+                                <h4 style="color: #373735;">{{ daily_sale.other_sales|korean_won_with_unit }}</h4>
                             </div>
                         </div>
                     </div>
@@ -67,7 +68,7 @@
                         <div class="card bg-brand-green">
                             <div class="card-body text-center">
                                 <h6>총 매출</h6>
-                                <h4><strong>{{ daily_sale.total_sales|floatformat:0 }}원</strong></h4>
+                                <h4><strong>{{ daily_sale.total_sales|korean_won_with_unit }}</strong></h4>
                             </div>
                         </div>
                     </div>

--- a/be/glossymatcha/templates/glossymatcha/daily_sales/list.html
+++ b/be/glossymatcha/templates/glossymatcha/daily_sales/list.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}일별 매출 관리 - Glossy Matcha{% endblock %}
 
@@ -53,13 +54,13 @@
                                 <br><small class="text-muted">{{ daily_sale.date|date:"l" }}</small>
                             </td>
                             <td class="text-end">
-                                <span style="color: #00563f;">{{ daily_sale.offline_sales|floatformat:0 }}원</span>
+                                <span style="color: #00563f;">{{ daily_sale.offline_sales|korean_won_with_unit }}</span>
                             </td>
                             <td class="text-end">
-                                <span style="color: #DAE3D8;">{{ daily_sale.other_sales|floatformat:0 }}원</span>
+                                <span style="color: #DAE3D8;">{{ daily_sale.other_sales|korean_won_with_unit }}</span>
                             </td>
                             <td class="text-end">
-                                <strong style="color: #373735;">{{ daily_sale.total_sales|floatformat:0 }}원</strong>
+                                <strong style="color: #373735;">{{ daily_sale.total_sales|korean_won_with_unit }}</strong>
                             </td>
                             <td>
                                 {% if daily_sale.memo %}

--- a/be/glossymatcha/templates/glossymatcha/dashboard.html
+++ b/be/glossymatcha/templates/glossymatcha/dashboard.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}대시보드 - Glossy Matcha{% endblock %}
 
@@ -30,7 +31,7 @@
             <div class="card-body text-center">
                 <i class="bi bi-calendar-day dashboard-icon mb-3"></i>
                 <h5 class="card-title">오늘 매출</h5>
-                <div class="stat-number">{{ today_sales|floatformat:0|default:"0" }}원</div>
+                <div class="stat-number">{{ today_sales|korean_won_with_unit|default:"0원" }}</div>
                 <small class="text-muted">{{ today|date:"m월 d일" }} 매출액</small>
             </div>
         </div>
@@ -41,7 +42,7 @@
             <div class="card-body text-center">
                 <i class="bi bi-graph-up dashboard-icon mb-3"></i>
                 <h5 class="card-title">이번 달 매출</h5>
-                <div class="stat-number">{{ monthly_sales|floatformat:0|default:"0" }}원</div>
+                <div class="stat-number">{{ monthly_sales|korean_won_with_unit|default:"0원" }}</div>
                 <small class="text-muted">{{ today|date:"Y년 m월" }} 누적 매출</small>
             </div>
         </div>
@@ -140,7 +141,7 @@
                                     <td>
                                         <span class="badge bg-primary">일별</span>
                                     </td>
-                                    <td class="text-end">{{ sale.total_sales|floatformat:0 }}원</td>
+                                    <td class="text-end">{{ sale.total_sales|korean_won_with_unit }}</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>

--- a/be/glossymatcha/templates/glossymatcha/sales/delete.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/delete.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}월별 매출 삭제{% endblock %}
 
@@ -23,9 +24,9 @@
                         <strong style="color: #373735;">매출 정보:</strong>
                         <ul class="list-unstyled mt-2" style="color: #373735;">
                             <li><strong>기간:</strong> {{ object.year }}년 {{ object.month }}월</li>
-                            <li><strong>총 매출:</strong> {{ object.total_sales|floatformat:0 }}원</li>
-                            <li><strong>총 원가:</strong> {{ object.total_cost|floatformat:0 }}원</li>
-                            <li><strong>순이익:</strong> {{ object.net_profit|floatformat:0 }}원</li>
+                            <li><strong>총 매출:</strong> {{ object.total_sales|korean_won_with_unit }}</li>
+                            <li><strong>총 원가:</strong> {{ object.total_cost|korean_won_with_unit }}</li>
+                            <li><strong>순이익:</strong> {{ object.net_profit|korean_won_with_unit }}</li>
                         </ul>
                     </div>
                     

--- a/be/glossymatcha/templates/glossymatcha/sales/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/detail.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}{{ sale.year }}년 {{ sale.month }}월 매출 상세 - Glossy Matcha{% endblock %}
 
@@ -37,15 +38,15 @@
                 <table class="table table-borderless">
                     <tr>
                         <td class="text-muted" width="50%">오프라인 매출</td>
-                        <td class="text-end"><strong>{{ sale.offline_sales|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.offline_sales|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr>
                         <td class="text-muted">기타 매출</td>
-                        <td class="text-end"><strong>{{ sale.other_sales|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.other_sales|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr class="border-top">
                         <td class="text-muted"><strong>소계</strong></td>
-                        <td class="text-end"><strong class="text-primary">{{ sale.total_sales|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong class="text-primary">{{ sale.total_sales|korean_won_with_unit }}</strong></td>
                     </tr>
                 </table>
             </div>
@@ -62,23 +63,23 @@
                 <table class="table table-borderless">
                     <tr>
                         <td class="text-muted" width="50%">재료비</td>
-                        <td class="text-end"><strong>{{ sale.material_cost|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.material_cost|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr>
                         <td class="text-muted">노무비</td>
-                        <td class="text-end"><strong>{{ sale.labor_cost|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.labor_cost|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr>
                         <td class="text-muted">경비-소모품</td>
-                        <td class="text-end"><strong>{{ sale.supplies_expense|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.supplies_expense|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr>
                         <td class="text-muted">경비-기타</td>
-                        <td class="text-end"><strong>{{ sale.other_expense|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.other_expense|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr class="border-top">
                         <td class="text-muted"><strong>소계</strong></td>
-                        <td class="text-end"><strong class="text-warning">{{ sale.total_cost|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong class="text-warning">{{ sale.total_cost|korean_won_with_unit }}</strong></td>
                     </tr>
                 </table>
             </div>
@@ -97,17 +98,17 @@
                         <td class="text-muted" width="50%">1차 매출이익</td>
                         <td class="text-end">
                             <strong class="{% if sale.gross_profit >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                {{ sale.gross_profit|floatformat:0 }}원
+                                {{ sale.gross_profit|korean_won_with_unit }}
                             </strong>
                         </td>
                     </tr>
                     <tr>
                         <td class="text-muted">재고금액</td>
-                        <td class="text-end"><strong>{{ sale.inventory_amount|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.inventory_amount|korean_won_with_unit }}</strong></td>
                     </tr>
                     <tr>
                         <td class="text-muted">실 사용금액</td>
-                        <td class="text-end"><strong>{{ sale.actual_usage_amount|floatformat:0 }}원</strong></td>
+                        <td class="text-end"><strong>{{ sale.actual_usage_amount|korean_won_with_unit }}</strong></td>
                     </tr>
                 </table>
             </div>

--- a/be/glossymatcha/templates/glossymatcha/sales/list.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/list.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}매출 관리 - Glossy Matcha{% endblock %}
 
@@ -33,7 +34,7 @@
         <div class="card">
             <div class="card-body text-center">
                 <h5 class="text-primary">
-                    {{ total_sales_sum|floatformat:0 }}원
+                    {{ total_sales_sum|korean_won_with_unit }}
                 </h5>
                 <small class="text-muted">총 매출</small>
             </div>
@@ -43,7 +44,7 @@
         <div class="card">
             <div class="card-body text-center">
                 <h5 class="text-warning">
-                    {{ total_cost_sum|floatformat:0 }}원
+                    {{ total_cost_sum|korean_won_with_unit }}
                 </h5>
                 <small class="text-muted">총 원가</small>
             </div>
@@ -53,7 +54,7 @@
         <div class="card">
             <div class="card-body text-center">
                 <h5 class="text-success">
-                    {{ total_profit_sum|floatformat:0 }}원
+                    {{ total_profit_sum|korean_won_with_unit }}
                 </h5>
                 <small class="text-muted">총 이익</small>
             </div>
@@ -96,14 +97,14 @@
                                 <strong>{{ sale.year }}년 {{ sale.month }}월</strong>
                             </td>
                             <td class="text-end">
-                                <strong class="text-primary">{{ sale.total_sales|floatformat:0 }}원</strong>
+                                <strong class="text-primary">{{ sale.total_sales|korean_won_with_unit }}</strong>
                             </td>
                             <td class="text-end">
-                                <strong class="text-warning">{{ sale.total_cost|floatformat:0 }}원</strong>
+                                <strong class="text-warning">{{ sale.total_cost|korean_won_with_unit }}</strong>
                             </td>
                             <td class="text-end">
                                 <strong class="{% if sale.gross_profit >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                    {{ sale.gross_profit|floatformat:0 }}원
+                                    {{ sale.gross_profit|korean_won_with_unit }}
                                 </strong>
                             </td>
                             <td>

--- a/be/glossymatcha/templates/glossymatcha/yearly_sales/create.html
+++ b/be/glossymatcha/templates/glossymatcha/yearly_sales/create.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}
     {% if yearly_sale %}연별 매출 수정{% else %}연별 매출 입력{% endif %} - Glossy Matcha
@@ -43,7 +44,7 @@
                         <div class="col-md-6 mb-3">
                             <label class="form-label">연간 총 재료비</label>
                             <div class="p-2 bg-light border rounded">
-                                <strong>{{ yearly_sale.total_material_cost|floatformat:0 }}원</strong>
+                                <strong>{{ yearly_sale.total_material_cost|korean_won_with_unit }}</strong>
                                 <small class="text-muted d-block">월별 재료비 합계</small>
                             </div>
                         </div>
@@ -51,7 +52,7 @@
                         <div class="col-md-6 mb-3">
                             <label class="form-label">연간 총 노무비</label>
                             <div class="p-2 bg-light border rounded">
-                                <strong>{{ yearly_sale.total_labor_cost|floatformat:0 }}원</strong>
+                                <strong>{{ yearly_sale.total_labor_cost|korean_won_with_unit }}</strong>
                                 <small class="text-muted d-block">월별 노무비 합계</small>
                             </div>
                         </div>
@@ -61,7 +62,7 @@
                         <div class="col-md-6 mb-3">
                             <label class="form-label">연간 총 경비-소모품</label>
                             <div class="p-2 bg-light border rounded">
-                                <strong>{{ yearly_sale.total_supplies_expense|floatformat:0 }}원</strong>
+                                <strong>{{ yearly_sale.total_supplies_expense|korean_won_with_unit }}</strong>
                                 <small class="text-muted d-block">월별 소모품비 합계</small>
                             </div>
                         </div>
@@ -69,7 +70,7 @@
                         <div class="col-md-6 mb-3">
                             <label class="form-label">연간 총 경비-기타</label>
                             <div class="p-2 bg-light border rounded">
-                                <strong>{{ yearly_sale.total_other_expense|floatformat:0 }}원</strong>
+                                <strong>{{ yearly_sale.total_other_expense|korean_won_with_unit }}</strong>
                                 <small class="text-muted d-block">월별 기타경비 합계</small>
                             </div>
                         </div>

--- a/be/glossymatcha/templates/glossymatcha/yearly_sales/delete.html
+++ b/be/glossymatcha/templates/glossymatcha/yearly_sales/delete.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}연별 매출 삭제{% endblock %}
 
@@ -23,9 +24,9 @@
                         <strong style="color: #373735;">매출 정보:</strong>
                         <ul class="list-unstyled mt-2" style="color: #373735;">
                             <li><strong>연도:</strong> {{ object.year }}년</li>
-                            <li><strong>총 매출:</strong> {{ object.total_sales|floatformat:0 }}원</li>
-                            <li><strong>총 원가:</strong> {{ object.total_cost|floatformat:0 }}원</li>
-                            <li><strong>순이익:</strong> {{ object.net_profit|floatformat:0 }}원</li>
+                            <li><strong>총 매출:</strong> {{ object.total_sales|korean_won_with_unit }}</li>
+                            <li><strong>총 원가:</strong> {{ object.total_cost|korean_won_with_unit }}</li>
+                            <li><strong>순이익:</strong> {{ object.net_profit|korean_won_with_unit }}</li>
                         </ul>
                     </div>
                     

--- a/be/glossymatcha/templates/glossymatcha/yearly_sales/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/yearly_sales/detail.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}{{ yearly_sale.year }}년 연별 매출 상세 - Glossy Matcha{% endblock %}
 
@@ -50,7 +51,7 @@
                         <div class="card bg-brand-green">
                             <div class="card-body text-center">
                                 <h6>연간 총 매출</h6>
-                                <h3><strong>{{ yearly_sale.total_sales|floatformat:0 }}원</strong></h3>
+                                <h3><strong>{{ yearly_sale.total_sales|korean_won_with_unit }}</strong></h3>
                                 <small>월별 매출 자동 합산</small>
                             </div>
                         </div>
@@ -59,7 +60,7 @@
                         <div class="card" style="background-color: #373735; color: white;">
                             <div class="card-body text-center">
                                 <h6>연간 총 원가</h6>
-                                <h3><strong>{{ yearly_sale.total_cost|floatformat:0 }}원</strong></h3>
+                                <h3><strong>{{ yearly_sale.total_cost|korean_won_with_unit }}</strong></h3>
                                 <small>월별 원가 자동 합산</small>
                             </div>
                         </div>
@@ -68,7 +69,7 @@
                         <div class="card {% if yearly_sale.gross_profit >= 0 %}bg-brand-green-light{% else %}bg-danger{% endif %}" style="color: #373735;">
                             <div class="card-body text-center">
                                 <h6>연간 순이익</h6>
-                                <h3><strong>{{ yearly_sale.gross_profit|floatformat:0 }}원</strong></h3>
+                                <h3><strong>{{ yearly_sale.gross_profit|korean_won_with_unit }}</strong></h3>
                                 <small>매출 - 원가</small>
                             </div>
                         </div>
@@ -83,11 +84,11 @@
                                 <h6 style="color: #00563f;" class="mb-3">연간 매출 구성 (자동 계산)</h6>
                                 <div class="d-flex justify-content-between mb-2">
                                     <span>오프라인 매출:</span>
-                                    <span style="color: #00563f;">{{ yearly_sale.offline_sales|floatformat:0 }}원</span>
+                                    <span style="color: #00563f;">{{ yearly_sale.offline_sales|korean_won_with_unit }}</span>
                                 </div>
                                 <div class="d-flex justify-content-between">
                                     <span>기타 매출:</span>
-                                    <span style="color: #00563f;">{{ yearly_sale.other_sales|floatformat:0 }}원</span>
+                                    <span style="color: #00563f;">{{ yearly_sale.other_sales|korean_won_with_unit }}</span>
                                 </div>
                             </div>
                         </div>
@@ -98,19 +99,19 @@
                                 <h6 style="color: #373735;" class="mb-3">연간 원가 구성 (자동 계산)</h6>
                                 <div class="d-flex justify-content-between mb-2">
                                     <span>재료비:</span>
-                                    <span>{{ yearly_sale.total_material_cost|floatformat:0 }}원</span>
+                                    <span>{{ yearly_sale.total_material_cost|korean_won_with_unit }}</span>
                                 </div>
                                 <div class="d-flex justify-content-between mb-2">
                                     <span>노무비:</span>
-                                    <span>{{ yearly_sale.total_labor_cost|floatformat:0 }}원</span>
+                                    <span>{{ yearly_sale.total_labor_cost|korean_won_with_unit }}</span>
                                 </div>
                                 <div class="d-flex justify-content-between mb-2">
                                     <span>경비-소모품:</span>
-                                    <span>{{ yearly_sale.total_supplies_expense|floatformat:0 }}원</span>
+                                    <span>{{ yearly_sale.total_supplies_expense|korean_won_with_unit }}</span>
                                 </div>
                                 <div class="d-flex justify-content-between">
                                     <span>경비-기타:</span>
-                                    <span>{{ yearly_sale.total_other_expense|floatformat:0 }}원</span>
+                                    <span>{{ yearly_sale.total_other_expense|korean_won_with_unit }}</span>
                                 </div>
                             </div>
                         </div>

--- a/be/glossymatcha/templates/glossymatcha/yearly_sales/list.html
+++ b/be/glossymatcha/templates/glossymatcha/yearly_sales/list.html
@@ -1,4 +1,5 @@
 {% extends 'glossymatcha/base.html' %}
+{% load money_filters %}
 
 {% block title %}연별 매출 관리 - Glossy Matcha{% endblock %}
 
@@ -52,14 +53,14 @@
                                 <strong>{{ yearly_sale.year }}년</strong>
                             </td>
                             <td class="text-end">
-                                <strong style="color: #00563f;">{{ yearly_sale.total_sales|floatformat:0 }}원</strong>
+                                <strong style="color: #00563f;">{{ yearly_sale.total_sales|korean_won_with_unit }}</strong>
                             </td>
                             <td class="text-end">
-                                <strong style="color: #373735;">{{ yearly_sale.total_cost|floatformat:0 }}원</strong>
+                                <strong style="color: #373735;">{{ yearly_sale.total_cost|korean_won_with_unit }}</strong>
                             </td>
                             <td class="text-end">
                                 <strong class="{% if yearly_sale.gross_profit >= 0 %}" style="color: #00563f;{% else %}text-danger{% endif %}">
-                                    {{ yearly_sale.gross_profit|floatformat:0 }}원
+                                    {{ yearly_sale.gross_profit|korean_won_with_unit }}
                                 </strong>
                             </td>
                             <td>


### PR DESCRIPTION
- 기존 {{ value|floatformat:0 }}원 → {{ value|korean_won_with_unit }}
- 각 템플릿에 {% load money_filters %} 태그 추가
- 이미 정의된 korean_won_with_unit 필터 활용하여 자동 콤마 포맷팅 및 원화 단위 표시