### PR TITLE
[BE] fix: 일별 매출 관리 기타매출을 선택사항으로 변경

### DIFF
--- a/be/glossymatcha/forms.py
+++ b/be/glossymatcha/forms.py
@@ -195,7 +195,7 @@ class DailySalesForm(forms.ModelForm):
             'other_sales': forms.NumberInput(attrs={
                 'class': 'form-control',
                 'min': '0',
-                'placeholder': '기타 매출을 입력하세요'
+                'placeholder': '기타 매출을 입력하세요 (ex : 온라인 매출, 배달 매출 등)',
             }),
             'memo': forms.Textarea(attrs={
                 'class': 'form-control',
@@ -203,6 +203,10 @@ class DailySalesForm(forms.ModelForm):
                 'placeholder': '메모를 입력하세요 (선택사항)'
             }),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['other_sales'].required = False
 
 class SalesForm(forms.ModelForm):
     class Meta:

--- a/be/glossymatcha/templates/glossymatcha/daily_sales/create.html
+++ b/be/glossymatcha/templates/glossymatcha/daily_sales/create.html
@@ -33,9 +33,9 @@
                     <h6 class="text-primary mb-3"><i class="bi bi-graph-up me-2"></i>일별 매출</h6>
                     <div class="row mb-4">
                         <div class="col-md-6 mb-3">
-                            <label for="{{ form.offline_sales.id_for_label }}" class="form-label">오프라인 매출</label>
+                            <label for="{{ form.offline_sales.id_for_label }}" class="form-label">오프라인 매출 *</label>
                             <div class="input-group">
-                                <input type="text" name="offline_sales" id="id_offline_sales" class="form-control money-input" value="{{ form.offline_sales.value|default:'' }}">
+                                <input type="text" name="offline_sales" id="id_offline_sales" class="form-control money-input" value="{{ form.offline_sales.value|default:'' }}" required>
                                 <span class="input-group-text">원</span>
                             </div>
                             {% if form.offline_sales.errors %}
@@ -44,14 +44,15 @@
                         </div>
                         
                         <div class="col-md-6 mb-3">
-                            <label for="{{ form.other_sales.id_for_label }}" class="form-label">기타 매출</label>
+                            <label for="{{ form.other_sales.id_for_label }}" class="form-label">기타 매출 <small class="text-muted">(선택사항)</small></label>
                             <div class="input-group">
-                                <input type="text" name="other_sales" id="id_other_sales" class="form-control money-input" value="{{ form.other_sales.value|default:'' }}">
+                                <input type="text" name="other_sales" id="id_other_sales" class="form-control money-input" value="{{ form.other_sales.value|default:'' }}" placeholder="0">
                                 <span class="input-group-text">원</span>
                             </div>
                             {% if form.other_sales.errors %}
                                 <div class="text-danger small">{{ form.other_sales.errors.0 }}</div>
                             {% endif %}
+                            <small class="text-muted">입력하지 않으면 0원으로 처리됩니다.</small>
                         </div>
                     </div>
                     


### PR DESCRIPTION
## 폼 수정
- DailySalesForm의 __init__ 메서드에서 other_sales 필드를 선택사항으로 설정 (required = False)
- placeholder 텍스트를 "기타 매출을 입력하세요 (선택사항)"으로 변경
---
## 템플릿 UI 개선
- 기타 매출 라벨에 "(선택사항)" 표시 추가
- 입력 필드에 placeholder="0" 추가
- 안내 텍스트 "입력하지 않으면 0원으로 처리됩니다." 추가
- 오프라인 매출은 필수 항목임을 명시 ("*" 표시 및 required 속성)