### PR TITLE
[BE] fix: 월별 매출 매출원가, 식재료 관련 기입 선택사항으로 수정

### DIFF
--- a/be/glossymatcha/forms.py
+++ b/be/glossymatcha/forms.py
@@ -208,6 +208,15 @@ class DailySalesForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields['other_sales'].required = False
 
+    def clean(self):
+        cleaned_data = super().clean()
+        
+        # other_sales가 빈 값이면 0으로 처리
+        if not cleaned_data.get('other_sales'):
+            cleaned_data['other_sales'] = 0
+            
+        return cleaned_data
+
 class SalesForm(forms.ModelForm):
     class Meta:
         model = Sales
@@ -258,10 +267,30 @@ class SalesForm(forms.ModelForm):
             }),
         }
     
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # 매출원가 관련 필드들을 선택사항으로 설정
+        self.fields['material_cost'].required = False
+        self.fields['labor_cost'].required = False
+        self.fields['supplies_expense'].required = False
+        self.fields['other_expense'].required = False
+        self.fields['inventory_amount'].required = False
+        self.fields['actual_usage_amount'].required = False
+    
     def clean(self):
         cleaned_data = super().clean()
         year = cleaned_data.get('year')
         month = cleaned_data.get('month')
+
+        # 선택사항 필드들의 빈 값을 0으로 처리
+        optional_fields = [
+            'material_cost', 'labor_cost', 'supplies_expense', 
+            'other_expense', 'inventory_amount', 'actual_usage_amount'
+        ]
+        
+        for field_name in optional_fields:
+            if not cleaned_data.get(field_name):
+                cleaned_data[field_name] = 0
 
         if year and month:
             # 기존 월별 매출 데이터 중복 검사

--- a/be/glossymatcha/templates/glossymatcha/sales/create.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/create.html
@@ -41,11 +41,11 @@
                     <div class="alert alert-info mb-4">
                         <h6 class="text-primary mb-2"><i class="bi bi-info-circle me-2"></i>매출 정보</h6>
                         <p class="mb-1">월별 매출은 일별 매출 데이터에서 자동으로 계산됩니다.</p>
-                        <p class="mb-0">매출원가와 식재료 관련 정보만 입력하시면 됩니다.</p>
+                        <p class="mb-0">매출원가와 식재료 관련 정보는 선택사항입니다. 필요한 항목만 입력하세요.</p>
                     </div>
                     
                     <!-- 매출원가 항목 -->
-                    <h6 class="text-warning mb-3"><i class="bi bi-graph-down me-2"></i>매출원가</h6>
+                    <h6 class="text-warning mb-3"><i class="bi bi-graph-down me-2"></i>매출원가 <small class="text-muted">(선택사항)</small></h6>
                     <div class="row mb-4">
                         <div class="col-md-6 mb-3">
                             <label for="{{ form.material_cost.id_for_label }}" class="form-label">재료비</label>
@@ -95,7 +95,7 @@
                     </div>
                     
                     <!-- 식재료 관련 -->
-                    <h6 class="text-success mb-3"><i class="bi bi-basket me-2"></i>식재료 관련</h6>
+                    <h6 class="text-success mb-3"><i class="bi bi-basket me-2"></i>식재료 관련 <small class="text-muted">(선택사항)</small></h6>
                     <div class="row mb-4">
                         <div class="col-md-6 mb-3">
                             <label for="{{ form.inventory_amount.id_for_label }}" class="form-label">재고금액</label>


### PR DESCRIPTION
## 해결방안
1. 폼 수정 (SalesForm):
  - __init__ 메서드 추가
  - 다음 필드들을 선택사항으로 설정:
      - material_cost (재료비)
      - labor_cost (노무비)
      - supplies_expense (경비-소모품)
      - other_expense (경비-기타)
      - inventory_amount (재고금액)
      - actual_usage_amount (실 사용금액)
2. 템플릿 UI 개선:
    - "매출원가 (선택사항)" 섹션 헤더 수정
    - "식재료 관련 (선택사항)" 섹션 헤더 수정
    - 안내 문구를 "매출원가와 식재료 관련 정보는 선택사항입니다. 필요한 항목만 입력하세요."로 변경
3. SalesForm의 clean 메서드 수정:
    - 선택사항 필드들 (material_cost, labor_cost, supplies_expense, other_expense, inventory_amount,
  actual_usage_amount)의 빈 값을 자동으로 0으로 처리
  2. DailySalesForm의 clean 메서드 추가:
    - other_sales 필드가 비어있으면 0으로 처리