### PR TITLE
[BE] fix: 근무형태별로 나눈 다음 입사일 기준 오름차순 정렬로 수정

### DIFF
--- a/be/glossymatcha/models.py
+++ b/be/glossymatcha/models.py
@@ -154,7 +154,7 @@ class Staff(models.Model):
     class Meta:
         verbose_name = "직원"
         verbose_name_plural = "직원"
-        ordering = ['resignation_date', 'employee_type', 'name']
+        ordering = ['resignation_date', 'employee_type', 'hire_date', 'name']
     
     @property
     def is_active(self):


### PR DESCRIPTION
## 정렬 순서
- resignation_date - 재직중(null)이 먼저, 퇴사자가 나중에
- employee_type - 정직원, 파트타임, 퇴사 순서
- hire_date - 입사일 오름차순 (먼저 입사한 직원부터)
- name - 같은 입사일인 경우 이름순