### PR TITLE
[BE] fix: 중복되는 daily 매출 url 삭제되면서 변경된 url name으로 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/base.html
+++ b/be/glossymatcha/templates/glossymatcha/base.html
@@ -40,7 +40,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link text-white" href="{% url 'sales_list' %}">
+                        <a class="nav-link text-white" href="{% url 'daily_sales_list' %}">
                             <i class="bi bi-graph-up me-1"></i>매출관리
                         </a>
                     </li>

--- a/be/glossymatcha/templates/glossymatcha/daily_sales/list.html
+++ b/be/glossymatcha/templates/glossymatcha/daily_sales/list.html
@@ -20,7 +20,7 @@
                 <span class="visually-hidden">더보기</span>
             </button>
             <ul class="dropdown-menu">
-                <li><a class="dropdown-item" href="{% url 'monthly_sales_list' %}"><i class="bi bi-calendar3 me-2"></i>월별 매출 목록</a></li>
+                <li><a class="dropdown-item" href="{% url 'sales_list' %}"><i class="bi bi-calendar3 me-2"></i>월별 매출 목록</a></li>
                 <li><a class="dropdown-item" href="{% url 'yearly_sales_list' %}"><i class="bi bi-bar-chart me-2"></i>연별 매출 목록</a></li>
             </ul>
         </div>

--- a/be/glossymatcha/templates/glossymatcha/dashboard.html
+++ b/be/glossymatcha/templates/glossymatcha/dashboard.html
@@ -91,7 +91,7 @@
                         </a>
                     </div>
                     <div class="col-lg-2 col-md-4 mb-2">
-                        <a href="{% url 'monthly_sales_create' %}" class="btn btn-outline-primary w-100">
+                        <a href="{% url 'sales_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-calendar3 me-2"></i>월별 매출
                         </a>
                     </div>

--- a/be/glossymatcha/templates/glossymatcha/sales/create.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/create.html
@@ -140,7 +140,7 @@
                     {% endif %}
                     
                     <div class="d-flex justify-content-between">
-                        <a href="{% url 'monthly_sales_list' %}" class="btn btn-secondary">
+                        <a href="{% url 'sales_list' %}" class="btn btn-secondary">
                             <i class="bi bi-arrow-left me-2"></i>목록으로
                         </a>
                         <button type="submit" class="btn btn-primary">

--- a/be/glossymatcha/templates/glossymatcha/sales/delete.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/delete.html
@@ -40,7 +40,7 @@
                         <button type="submit" class="btn px-4" style="background-color: #373735; color: #f2efe8; border: none;">
                             <i class="fas fa-trash me-2"></i>삭제
                         </button>
-                        <a href="{% url 'monthly_sales_detail' object.pk %}" class="btn px-4" style="background-color: #00563f; color: #f2efe8; text-decoration: none;">
+                        <a href="{% url 'sales_detail' object.pk %}" class="btn px-4" style="background-color: #00563f; color: #f2efe8; text-decoration: none;">
                             <i class="fas fa-arrow-left me-2"></i>취소
                         </a>
                     </form>

--- a/be/glossymatcha/templates/glossymatcha/sales/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/detail.html
@@ -18,7 +18,7 @@
         <a href="{% url 'sales_update' sale.pk %}" class="btn btn-primary">
             <i class="bi bi-pencil me-2"></i>수정
         </a>
-        <a href="{% url 'monthly_sales_delete' sale.pk %}" class="btn" style="background-color: #373735; color: #f2efe8; border: none;">
+        <a href="{% url 'sales_delete' sale.pk %}" class="btn" style="background-color: #373735; color: #f2efe8; border: none;">
             <i class="bi bi-trash me-2"></i>삭제
         </a>
         <a href="{% url 'sales_list' %}" class="btn btn-outline-secondary">

--- a/be/glossymatcha/templates/glossymatcha/sales/list.html
+++ b/be/glossymatcha/templates/glossymatcha/sales/list.html
@@ -13,7 +13,7 @@
     </div>
     <div class="col-md-6 text-end">
         <div class="btn-group">
-            <a href="{% url 'monthly_sales_create' %}" class="btn btn-primary">
+            <a href="{% url 'sales_create' %}" class="btn btn-primary">
                 <i class="bi bi-plus-circle me-2"></i>월별 매출 입력
             </a>
             <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown">
@@ -119,13 +119,13 @@
                             </td>
                             <td>
                                 <div class="action-buttons">
-                                    <a href="{% url 'monthly_sales_detail' sale.pk %}" class="btn btn-sm btn-outline-primary">
+                                    <a href="{% url 'sales_detail' sale.pk %}" class="btn btn-sm btn-outline-primary">
                                         <i class="bi bi-eye"></i>
                                     </a>
-                                    <a href="{% url 'monthly_sales_update' sale.pk %}" class="btn btn-sm btn-outline-secondary">
+                                    <a href="{% url 'sales_update' sale.pk %}" class="btn btn-sm btn-outline-secondary">
                                         <i class="bi bi-pencil"></i>
                                     </a>
-                                    <a href="{% url 'monthly_sales_delete' sale.pk %}" class="btn btn-sm btn-outline-danger">
+                                    <a href="{% url 'sales_delete' sale.pk %}" class="btn btn-sm btn-outline-danger">
                                         <i class="bi bi-trash"></i>
                                     </a>
                                 </div>
@@ -140,7 +140,7 @@
                 <i class="bi bi-graph-up" style="font-size: 4rem; color: #ddd;"></i>
                 <h4 class="mt-3 text-muted">등록된 월별 매출이 없습니다</h4>
                 <p class="text-muted">첫 번째 월별 매출을 입력해보세요.</p>
-                <a href="{% url 'monthly_sales_create' %}" class="btn btn-primary">
+                <a href="{% url 'sales_create' %}" class="btn btn-primary">
                     <i class="bi bi-plus-circle me-2"></i>월별 매출 입력하기
                 </a>
             </div>

--- a/be/glossymatcha/templates/glossymatcha/yearly_sales/list.html
+++ b/be/glossymatcha/templates/glossymatcha/yearly_sales/list.html
@@ -20,8 +20,8 @@
                 <span class="visually-hidden">더보기</span>
             </button>
             <ul class="dropdown-menu">
-                <li><a class="dropdown-item" href="{% url 'sales_list' %}"><i class="bi bi-calendar-day me-2"></i>일별 매출 목록</a></li>
-                <li><a class="dropdown-item" href="{% url 'monthly_sales_list' %}"><i class="bi bi-calendar3 me-2"></i>월별 매출 목록</a></li>
+                <li><a class="dropdown-item" href="{% url 'daily_sales_list' %}"><i class="bi bi-calendar-day me-2"></i>일별 매출 목록</a></li>
+                <li><a class="dropdown-item" href="{% url 'sales_list' %}"><i class="bi bi-calendar3 me-2"></i>월별 매출 목록</a></li>
             </ul>
         </div>
     </div>

--- a/be/glossymatcha/urls.py
+++ b/be/glossymatcha/urls.py
@@ -37,25 +37,18 @@ urlpatterns = [
     path('suppliers/<int:pk>/delete/', views.SuppliersDeleteView.as_view(), name='suppliers_delete'), # 거래처 삭제
 
     # Django Template Views for daily sales management(main)
-    path('sales/', views.DailySalesListView.as_view(), name='sales_list'),                      # 매출 관리 메인
-    path('sales/create/', views.DailySalesCreateView.as_view(), name='sales_create'),           # 매출 입력
-    path('sales/<int:pk>/', views.DailySalesDetailView.as_view(), name='sales_detail'),         # 매출 상세
-    path('sales/<int:pk>/update/', views.DailySalesUpdateView.as_view(), name='sales_update'),  # 매출 수정
-    path('sales/<int:pk>/delete/', views.DailySalesDeleteView.as_view(), name='sales_delete'),  # 매출 삭제
-    
-    # Django Template Views for daily sales management
-    path('daily-sales/', views.DailySalesListView.as_view(), name='daily_sales_list'),          # 일별 매출 목록
-    path('daily-sales/create/', views.DailySalesCreateView.as_view(), name='daily_sales_create'), # 일별 매출 등록
-    path('daily-sales/<int:pk>/', views.DailySalesDetailView.as_view(), name='daily_sales_detail'), # 일별 매출 상세
-    path('daily-sales/<int:pk>/update/', views.DailySalesUpdateView.as_view(), name='daily_sales_update'), # 일별 매출 수정
-    path('daily-sales/<int:pk>/delete/', views.DailySalesDeleteView.as_view(), name='daily_sales_delete'), # 일별 매출 삭제
+    path('sales/', views.DailySalesListView.as_view(), name='daily_sales_list'),                 # 매출 관리 메인 (일별)
+    path('sales/create/', views.DailySalesCreateView.as_view(), name='daily_sales_create'),      # 일별 매출 입력
+    path('sales/<int:pk>/', views.DailySalesDetailView.as_view(), name='daily_sales_detail'),    # 일별 매출 상세
+    path('sales/<int:pk>/update/', views.DailySalesUpdateView.as_view(), name='daily_sales_update'), # 일별 매출 수정
+    path('sales/<int:pk>/delete/', views.DailySalesDeleteView.as_view(), name='daily_sales_delete'), # 일별 매출 삭제
 
     # Django Template Views for monthly sales management
-    path('monthly-sales/', views.SalesListView.as_view(), name='monthly_sales_list'),           # 월별 매출 목록
-    path('monthly-sales/create/', views.SalesCreateView.as_view(), name='monthly_sales_create'), # 월별 매출 등록
-    path('monthly-sales/<int:pk>/', views.SalesDetailView.as_view(), name='monthly_sales_detail'), # 월별 매출 상세
-    path('monthly-sales/<int:pk>/update/', views.SalesUpdateView.as_view(), name='monthly_sales_update'), # 월별 매출 수정
-    path('monthly-sales/<int:pk>/delete/', views.SalesDeleteView.as_view(), name='monthly_sales_delete'), # 월별 매출 삭제
+    path('monthly-sales/', views.SalesListView.as_view(), name='sales_list'),                   # 월별 매출 목록
+    path('monthly-sales/create/', views.SalesCreateView.as_view(), name='sales_create'),        # 월별 매출 등록
+    path('monthly-sales/<int:pk>/', views.SalesDetailView.as_view(), name='sales_detail'),      # 월별 매출 상세
+    path('monthly-sales/<int:pk>/update/', views.SalesUpdateView.as_view(), name='sales_update'), # 월별 매출 수정
+    path('monthly-sales/<int:pk>/delete/', views.SalesDeleteView.as_view(), name='sales_delete'), # 월별 매출 삭제
 
     # Django Template Views for yearly sales management
     path('yearly-sales/', views.YearlySalesListView.as_view(), name='yearly_sales_list'),       # 연별 매출 목록

--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -745,7 +745,7 @@ class SalesCreateView(LoginRequiredMixin, CreateView):
     model = Sales
     form_class = SalesForm
     template_name = 'glossymatcha/sales/create.html'
-    success_url = reverse_lazy('monthly_sales_list')
+    success_url = reverse_lazy('sales_list')
 
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -773,7 +773,7 @@ class SalesUpdateView(LoginRequiredMixin, UpdateView):
     template_name = 'glossymatcha/sales/create.html'
 
     def get_success_url(self):
-        return reverse_lazy('monthly_sales_detail', kwargs={'pk': self.object.pk})
+        return reverse_lazy('sales_detail', kwargs={'pk': self.object.pk})
     
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -797,7 +797,7 @@ class SalesDeleteView(LoginRequiredMixin, DeleteView):
     """
     model = Sales
     template_name = 'glossymatcha/sales/delete.html'
-    success_url = reverse_lazy('monthly_sales_list')
+    success_url = reverse_lazy('sales_list')
 
     def delete(self, request, *args, **kwargs):
         self.object = self.get_object()


### PR DESCRIPTION
## 해결방안
1. 중복 URL 제거: daily-sales/ 경로들(46-51행) 모두 삭제
2. URL 이름 변경:
    - sales/ → daily_sales_list (일별매출 메인)
    - monthly-sales/ → sales_list (월별매출)
3. 모든 템플릿 참조 수정:
    - base.html: 메인 네비게이션
    - yearly_sales/list.html: 드롭다운 메뉴
    - daily_sales/list.html: 드롭다운 메뉴
    - sales/detail.html: 삭제 버튼
    - sales/create.html: 취소 버튼
4. views.py 수정: 월별매출 관련 success_url 업데이트
---
## NoReverseMatch 오류 해결
수정 완료:
1. sales/list.html: 모든 버튼 URL을 sales_*로 수정
2. sales/delete.html: 취소 버튼 URL 수정
3. dashboard.html: 월별매출 생성 버튼 URL 수정