### PR TITLE
[BE] fix: 일별 매출 눌렀을 때 월별 매출로 이동하는 오류 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/dashboard.html
+++ b/be/glossymatcha/templates/glossymatcha/dashboard.html
@@ -86,7 +86,7 @@
                         </a>
                     </div>
                     <div class="col-lg-2 col-md-4 mb-2">
-                        <a href="{% url 'sales_create' %}" class="btn btn-outline-primary w-100">
+                        <a href="{% url 'daily_sales_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-calendar-day me-2"></i>일별 매출
                         </a>
                     </div>


### PR DESCRIPTION
일별 매출 버튼이 sales_create (월별 매출 생성)을 가리키고 있었음 → daily_sales_create로 수정