### PR TITLE
[BE] fix: 배포서버에서 전화번호 복사 안되는 오류 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/suppliers/detail.html
+++ b/be/glossymatcha/templates/glossymatcha/suppliers/detail.html
@@ -168,12 +168,45 @@
 
 <script>
 function copyToClipboard(text) {
-    navigator.clipboard.writeText(text).then(function() {
-        // 성공 알림 (Bootstrap toast 등으로 개선 가능)
-        alert('거래처 정보가 클립보드에 복사되었습니다.');
-    }, function(err) {
-        console.error('클립보드 복사 실패: ', err);
-    });
+    // 최신 브라우저에서 navigator.clipboard 지원 여부 확인
+    if (navigator.clipboard && window.isSecureContext) {
+        // HTTPS 환경에서 clipboard API 사용
+        navigator.clipboard.writeText(text).then(function() {
+            alert('거래처 정보가 클립보드에 복사되었습니다.');
+        }, function(err) {
+            console.error('클립보드 복사 실패: ', err);
+            fallbackCopy(text);
+        });
+    } else {
+        // HTTP 환경이나 구버전 브라우저에서 대체 방법 사용
+        fallbackCopy(text);
+    }
+}
+
+function fallbackCopy(text) {
+    // 임시 textarea 요소를 생성하여 복사
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, 99999);
+    
+    try {
+        const successful = document.execCommand('copy');
+        if (successful) {
+            alert('거래처 정보가 클립보드에 복사되었습니다.');
+        } else {
+            alert('복사에 실패했습니다. 수동으로 복사해주세요.');
+        }
+    } catch (err) {
+        console.error('복사 실패:', err);
+        alert('복사에 실패했습니다. 수동으로 복사해주세요.');
+    } finally {
+        document.body.removeChild(textarea);
+    }
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## navigator.clipboard.writeText()는 HTTPS 환경에서만 작동, 배포 서버에서는 브라우저의 보안 정책으로 인해 실패하는 오류
---
## 대체 방법을 추가
- 환경 감지: navigator.clipboard와 window.isSecureContext 확인으로 HTTPS 환경 여부 판단
- 대체 방법 추가: HTTP 환경이나 구버전 브라우저에서는 document.execCommand('copy') 사용
- 오류 처리: 모든 복사 시도가 실패할 경우 사용자에게 수동 복사 안내