### PR TITLE
[BE] fix: 거래처 목록의 email도 gmail로 이동하게끔 수정

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/suppliers/list.html
+++ b/be/glossymatcha/templates/glossymatcha/suppliers/list.html
@@ -46,7 +46,7 @@
                             <td>{{ supplier.phone }}</td>
                             <td>
                                 {% if supplier.email %}
-                                    <a href="mailto:{{ supplier.email }}" class="text-decoration-none">
+                                    <a href="https://mail.google.com/mail/?view=cm&fs=1&to={{ supplier.email }}" target="_blank" class="text-decoration-none">
                                         {{ supplier.email }}
                                     </a>
                                 {% else %}


### PR DESCRIPTION
## 수정된 내용
- suppliers/list.html:49에서 mailto:를 Gmail URL로 변경
- target="_blank"로 새 탭에서 열리도록 설정