### PR TITLE
[FE] feat: 브랜드 소개 페이지 국영문 전환 구현

### DIFF
--- a/fe/messages/en.json
+++ b/fe/messages/en.json
@@ -112,32 +112,37 @@
         "history": {
             "title": "GLOSSY HISTORY",
             "location": "112, Johamhaean-ro, Jocheon-eup, Jeju-si, Jeju-do (Approx. 3,300㎡)",
-            "list": {
-                "item-1": {
-                    "date": "2023.09",
-                    "desc-1": "'GLOSSY MATCHA' OPENING"
-                },
-                "item-2": {
+            "items": [
+                { "date": "2023.09", "desc": ["'GLOSSY MATCHA' OPENING"] },
+                {
                     "date": "2024.09",
-                    "desc-1": "Select shop 'WITH GLOSSY' OPENING"
+                    "desc": ["Select shop 'WITH GLOSSY' OPENING"]
                 },
-                "item-3": {
+                {
                     "date": "2024.12",
-                    "desc": "Achieved $20,000 export record for the year (including GLOSSY MATCHA products)"
+                    "desc": [
+                        "Achieved $20,000 export record for the year (including GLOSSY MATCHA products)"
+                    ]
                 },
-                "item-4": {
+                {
                     "date": "2025.01",
-                    "desc": "Participated in 2025 SIRHA (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)"
+                    "desc": [
+                        "Participated in 2025 SIRHA (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)"
+                    ]
                 },
-                "item-5": {
+                {
                     "date": "2025.05",
-                    "desc": "Held POP-UP events in the USA and France and discussed follow-up export volumes"
+                    "desc": [
+                        "Held POP-UP events in the USA and France and discussed follow-up export volumes"
+                    ]
                 },
-                "item-6": {
+                {
                     "date": "2025.06",
-                    "desc": "Planned release of lifestyle shoe collaboration products (with Muleboy, green matcha color slippers)"
+                    "desc": [
+                        "Planned release of lifestyle shoe collaboration products (with Muleboy, green matcha color slippers)"
+                    ]
                 }
-            }
+            ]
         }
     }
 }

--- a/fe/messages/en.json
+++ b/fe/messages/en.json
@@ -1,52 +1,143 @@
 {
-  "navigation": {
-    "about": "About",
-    "products": "Products",
-    "test": "Matcha Test",
-    "contact": "Contact",
-    "language": "Language Change",
+    "navigation": {
+        "about": "About",
+        "products": "Products",
+        "test": "Matcha Test",
+        "contact": "Contact",
+        "language": "Language Change",
 
-    "menuOpen": "Menu Open",
-    "menuClose": "Menu Close"
-  },
-  "home": {
-    "homeContent": [
-      {
-        "title": "브랜드 소개",
-        "slogan": "Life With Glossy",
-        "subSlogan": "It makes every day a shining moment.",
-        "description": "사람들의 모든 순간들을 반짝이는 순간들로 만들어 줄 글로시 말차는 단순히 말차를 판매하는 브랜드가 아닌 다양한 감성과 컨텐츠가 담긴 관계적 브랜드로 성장할 것을 약속합니다.",
-        "source": "/videos/intro-pc.webm",
-        "sourceMb": "/videos/intro-mb.webm"
-      },
-      {
-        "title": "카페 소개",
-        "slogan": "Cafe Glossy Matcha",
-        "subSlogan": "제주의 동쪽, 가장 뜨는 핫플",
-        "sideBarImage": "/images/home/cafe-location.webp",
-        "description": "제주특별자치도 조천읍 조함해안로 112 에서 제주산 최상급 말차를 사용한 음료와 디저트를 맛보며 멋진 바다 전경과 편안함 '쉼'을 경험해보세요.",
-        "source": "/images/home/cafe-glossy-matcha.webp",
-        "link": "/about",
-        "linkText": "브랜드 소개"
-      },
-      {
-        "title": "제품 소개",
-        "slogan": "Glossy Signature",
-        "subSlogan": "자연의 원당과 대체당으로 블랜딩한 최적의 달콤함",
-        "description": "선조들로부터 이어진 전통 가공방식을 고수해 떫은 맛은 줄고 섬세하고 부드러운 깔끔한 끝맛으로 초심자들도 맛있게 드실 수 있어요.",
-        "source": "/images/home/glossy-signature.webp",
-        "link": "/products",
-        "linkText": "제품 소개"
-      },
-      {
-        "title": "말차 테스트",
-        "slogan": "Glossy Pick",
-        "subSlogan": "단 하나, 당신만을 위한 글로시 말차",
-        "description": "말차 스트레이트? 말차 모히또? 말차 라떼? 나와 어울리는 말차 메뉴를 찾고 글로시 말차에서 즐겨보세요!",
-        "source": "/images/home/matcha-test.webp",
-        "link": "/test",
-        "linkText": "테스트 바로가기"
-      }
-    ]
-  }
+        "menuOpen": "Menu Open",
+        "menuClose": "Menu Close"
+    },
+    "home": {
+        "homeContent": [
+            {
+                "title": "브랜드 소개",
+                "slogan": "Life With Glossy",
+                "subSlogan": "It makes every day a shining moment.",
+                "description": "사람들의 모든 순간들을 반짝이는 순간들로 만들어 줄 글로시 말차는 단순히 말차를 판매하는 브랜드가 아닌 다양한 감성과 컨텐츠가 담긴 관계적 브랜드로 성장할 것을 약속합니다.",
+                "source": "/videos/intro-pc.webm",
+                "sourceMb": "/videos/intro-mb.webm"
+            },
+            {
+                "title": "카페 소개",
+                "slogan": "Cafe Glossy Matcha",
+                "subSlogan": "제주의 동쪽, 가장 뜨는 핫플",
+                "sideBarImage": "/images/home/cafe-location.webp",
+                "description": "제주특별자치도 조천읍 조함해안로 112 에서 제주산 최상급 말차를 사용한 음료와 디저트를 맛보며 멋진 바다 전경과 편안함 '쉼'을 경험해보세요.",
+                "source": "/images/home/cafe-glossy-matcha.webp",
+                "link": "/about",
+                "linkText": "브랜드 소개"
+            },
+            {
+                "title": "제품 소개",
+                "slogan": "Glossy Signature",
+                "subSlogan": "자연의 원당과 대체당으로 블랜딩한 최적의 달콤함",
+                "description": "선조들로부터 이어진 전통 가공방식을 고수해 떫은 맛은 줄고 섬세하고 부드러운 깔끔한 끝맛으로 초심자들도 맛있게 드실 수 있어요.",
+                "source": "/images/home/glossy-signature.webp",
+                "link": "/products",
+                "linkText": "제품 소개"
+            },
+            {
+                "title": "말차 테스트",
+                "slogan": "Glossy Pick",
+                "subSlogan": "단 하나, 당신만을 위한 글로시 말차",
+                "description": "말차 스트레이트? 말차 모히또? 말차 라떼? 나와 어울리는 말차 메뉴를 찾고 글로시 말차에서 즐겨보세요!",
+                "source": "/images/home/matcha-test.webp",
+                "link": "/test",
+                "linkText": "테스트 바로가기"
+            }
+        ]
+    },
+    "about": {
+        "sub-nav": {
+            "intro": "About Us",
+            "philosophy": "Brand Philosophy",
+            "jeju-matcha": "Jeju Organic Matcha",
+            "history": "History"
+        },
+        "intro": {
+            "title": "LIFE WITH GLOSSY",
+            "slogan": "We make every day a shining moment.",
+            "description": {
+                "paragraph-1": "Glossy Matcha provides sparkling energy for everyone, helping them find their own joy and happiness, and making every moment of their lives shine.",
+                "paragraph-2": "Glossy Matcha promises to grow into a relational brand filled with diverse emotions and content, not just a brand that sells matcha, but one that brightens everyday life.",
+                "paragraph-3": "Glossy Matcha aims to help you find sparkle in your life, in the small everyday moments, starting with the little things together.",
+                "paragraph-4": "We are a brand that offers genuine products, content, and campaigns that can become a part of your daily life, promoting sustainable coexistence."
+            }
+        },
+        "philosophy": {
+            "title": "GLOSSY LIFE, GLOSSY MATCHA",
+            "list": {
+                "item-1": {
+                    "title": "LIGHT",
+                    "desc": "We pursue the shining moments of Jeju and everyday life."
+                },
+                "item-2": {
+                    "title": "NATURAL",
+                    "desc": "We constantly seek and research ways to live in harmony with nature."
+                },
+                "item-3": {
+                    "title": "TRAVEL",
+                    "desc": "We offer a lifestyle that can be enjoyed alongside travel."
+                }
+            }
+        },
+        "jeju-matcha": {
+            "intro": {
+                "title": "RELAX WITH GLOSSY",
+                "slogan": "Glossy Matcha gifts you true relaxation.",
+                "description": {
+                    "paragraph-1": "Matcha is the finest tea from Jeju. Glossy Matcha uses only 100% organic matcha of the highest quality.",
+                    "paragraph-2": "It captures the vibrant green vitality created by Jeju's pristine nature. The calming green aroma offers comfort and relaxation to all.",
+                    "paragraph-3": "The unique sweet yet rich aroma of matcha is a harmonious blend of freshness and gentle bitterness.",
+                    "paragraph-4": "Fill your body and mind with health and the refreshing spirit of green."
+                }
+            },
+            "feature": {
+                "item-1": {
+                    "title": "Organic First Flush Leaves",
+                    "description": "Made from 100% organic first flush tea leaves grown in Seogwipo Eco Farm, delivering a smoother and richer taste."
+                },
+                "item-2": {
+                    "title": "Sustainable Future",
+                    "description": "We collaborate with local farmers and artisans who care for the environment, moving toward a healthier and more sustainable future."
+                },
+                "item-3": {
+                    "title": "Commitment to Quality",
+                    "description": "Through processing techniques and distribution management backed by years of expertise, we produce matcha of the highest quality."
+                }
+            }
+        },
+        "history": {
+            "title": "GLOSSY HISTORY",
+            "location": "112, Johamhaean-ro, Jocheon-eup, Jeju-si, Jeju-do (Approx. 3,300㎡)",
+            "list": {
+                "item-1": {
+                    "date": "2023.09",
+                    "desc-1": "'GLOSSY MATCHA' OPENING"
+                },
+                "item-2": {
+                    "date": "2024.09",
+                    "desc-1": "Select shop 'WITH GLOSSY' OPENING"
+                },
+                "item-3": {
+                    "date": "2024.12",
+                    "desc": "Achieved $20,000 export record for the year (including GLOSSY MATCHA products)"
+                },
+                "item-4": {
+                    "date": "2025.01",
+                    "desc": "Participated in 2025 SIRHA (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)"
+                },
+                "item-5": {
+                    "date": "2025.05",
+                    "desc": "Held POP-UP events in the USA and France and discussed follow-up export volumes"
+                },
+                "item-6": {
+                    "date": "2025.06",
+                    "desc": "Planned release of lifestyle shoe collaboration products (with Muleboy, green matcha color slippers)"
+                }
+            }
+        }
+    }
 }

--- a/fe/messages/ko.json
+++ b/fe/messages/ko.json
@@ -1,52 +1,143 @@
 {
-  "navigation": {
-    "about": "브랜드 소개",
-    "products": "제품 소개",
-    "test": "말차 테스트",
-    "contact": "문의하기",
-    "language": "언어 변경",
+    "navigation": {
+        "about": "브랜드 소개",
+        "products": "제품 소개",
+        "test": "말차 테스트",
+        "contact": "문의하기",
+        "language": "언어 변경",
 
-    "menuOpen": "메뉴 열기",
-    "menuClose": "메뉴 닫기"
-  },
-  "home": {
-    "homeContent": [
-      {
-        "title": "브랜드 소개",
-        "slogan": "Life With Glossy",
-        "subSlogan": "모든 일상을 빛나는 순간으로 만듭니다.",
-        "description": "사람들의 모든 순간들을 반짝이는 순간들로 만들어 줄 글로시 말차는 단순히 말차를 판매하는 브랜드가 아닌 다양한 감성과 컨텐츠가 담긴 관계적 브랜드로 성장할 것을 약속합니다.",
-        "source": "/videos/intro-pc.webm",
-        "sourceMb": "/videos/intro-mb.webm"
-      },
-      {
-        "title": "카페 소개",
-        "slogan": "Cafe Glossy Matcha",
-        "subSlogan": "제주의 동쪽, 가장 뜨는 핫플",
-        "sideBarImage": "/images/home/cafe-location.webp",
-        "description": "제주특별자치도 조천읍 조함해안로 112 에서 제주산 최상급 말차를 사용한 음료와 디저트를 맛보며 멋진 바다 전경과 편안함 '쉼'을 경험해보세요.",
-        "source": "/images/home/cafe-glossy-matcha.webp",
-        "link": "/about",
-        "linkText": "브랜드 소개"
-      },
-      {
-        "title": "제품 소개",
-        "slogan": "Glossy Signature",
-        "subSlogan": "자연의 원당과 대체당으로 블랜딩한 최적의 달콤함",
-        "description": "선조들로부터 이어진 전통 가공방식을 고수해 떫은 맛은 줄고 섬세하고 부드러운 깔끔한 끝맛으로 초심자들도 맛있게 드실 수 있어요.",
-        "source": "/images/home/glossy-signature.webp",
-        "link": "/products",
-        "linkText": "제품 소개"
-      },
-      {
-        "title": "말차 테스트",
-        "slogan": "Glossy Pick",
-        "subSlogan": "단 하나, 당신만을 위한 글로시 말차",
-        "description": "말차 스트레이트? 말차 모히또? 말차 라떼? 나와 어울리는 말차 메뉴를 찾고 글로시 말차에서 즐겨보세요!",
-        "source": "/images/home/matcha-test.webp",
-        "link": "/test",
-        "linkText": "테스트 바로가기"
-      }
-    ]
-  }
+        "menuOpen": "메뉴 열기",
+        "menuClose": "메뉴 닫기"
+    },
+    "home": {
+        "homeContent": [
+            {
+                "title": "브랜드 소개",
+                "slogan": "Life With Glossy",
+                "subSlogan": "모든 일상을 빛나는 순간으로 만듭니다.",
+                "description": "사람들의 모든 순간들을 반짝이는 순간들로 만들어 줄 글로시 말차는 단순히 말차를 판매하는 브랜드가 아닌 다양한 감성과 컨텐츠가 담긴 관계적 브랜드로 성장할 것을 약속합니다.",
+                "source": "/videos/intro-pc.webm",
+                "sourceMb": "/videos/intro-mb.webm"
+            },
+            {
+                "title": "카페 소개",
+                "slogan": "Cafe Glossy Matcha",
+                "subSlogan": "제주의 동쪽, 가장 뜨는 핫플",
+                "sideBarImage": "/images/home/cafe-location.webp",
+                "description": "제주특별자치도 조천읍 조함해안로 112 에서 제주산 최상급 말차를 사용한 음료와 디저트를 맛보며 멋진 바다 전경과 편안함 '쉼'을 경험해보세요.",
+                "source": "/images/home/cafe-glossy-matcha.webp",
+                "link": "/about",
+                "linkText": "브랜드 소개"
+            },
+            {
+                "title": "제품 소개",
+                "slogan": "Glossy Signature",
+                "subSlogan": "자연의 원당과 대체당으로 블랜딩한 최적의 달콤함",
+                "description": "선조들로부터 이어진 전통 가공방식을 고수해 떫은 맛은 줄고 섬세하고 부드러운 깔끔한 끝맛으로 초심자들도 맛있게 드실 수 있어요.",
+                "source": "/images/home/glossy-signature.webp",
+                "link": "/products",
+                "linkText": "제품 소개"
+            },
+            {
+                "title": "말차 테스트",
+                "slogan": "Glossy Pick",
+                "subSlogan": "단 하나, 당신만을 위한 글로시 말차",
+                "description": "말차 스트레이트? 말차 모히또? 말차 라떼? 나와 어울리는 말차 메뉴를 찾고 글로시 말차에서 즐겨보세요!",
+                "source": "/images/home/matcha-test.webp",
+                "link": "/test",
+                "linkText": "테스트 바로가기"
+            }
+        ]
+    },
+    "about": {
+        "sub-nav": {
+            "intro": "브랜드 소개",
+            "philosophy": "브랜드 철학",
+            "jeju-matcha": "제주 유기농 말차",
+            "history": "연혁"
+        },
+        "intro": {
+            "title": "LIFE WITH GLOSSY",
+            "slogan": "모든 일상을 빛나는 순간으로 만듭니다.",
+            "description": {
+                "paragraph-1": "글로시말차는 모든 사람들을 위해 반짝이는 에너지를 제공하여 개인만의 즐거움과 기쁨을 찾고 그들의 모든 순간을 빛나게 도와줍니다.",
+                "paragraph-2": "일상을 빛나게 만들어 줄 글로시말차는 단순히 말차를 판매하는 브랜드가 아닌 다양한 감성과 컨텐츠가 담긴 관계적 브랜드로 성장할 것을 약속합니다.",
+                "paragraph-3": "당신의 삶, 사소한 일상과 순간에서 반짝거림을 찾을 수 있도록 글로시말차는 작은 것들부터 함께 시작하려고 합니다.",
+                "paragraph-4": "우리는 제품, 컨텐츠, 캠페인 그리고 당신의 일상이 될 수 있도록 지속가능한 공생을 위한 진전성있는 것들을 제공하는 브랜드입니다."
+            }
+        },
+        "philosophy": {
+            "title": "GLOSSY LIFE, GLOSSY MATCHA",
+            "list": {
+                "item-1": {
+                    "title": "LIGHT",
+                    "desc": "제주, 그리고 일상의 빛나는 순간을 지향합니다."
+                },
+                "item-2": {
+                    "title": "NATURAL",
+                    "desc": "자연과 함께할 수 있는 방향을 항상 고민하고 연구합니다."
+                },
+                "item-3": {
+                    "title": "TRAVEL",
+                    "desc": "여행과 함께 할 수 있는 라이프스타일을 제공합니다."
+                }
+            }
+        },
+        "jeju-matcha": {
+            "intro": {
+                "title": "RELAX WITH GLOSSY",
+                "slogan": "글로시말차는 진정한 휴식을 선물합니다.",
+                "description": {
+                    "paragraph-1": "말차는 제주에서 가장 우수한 차입니다. 글로시말차는 최고 품질의 100% 유기농 말차만을 사용하고 있습니다.",
+                    "paragraph-2": "제주의 청정 자연이 빚어낸 푸른 생명력을 그대로 담았습니다. 편안함을 선사하는 초록색의 향기는 모두에게 편안한 휴식을 선사합니다.",
+                    "paragraph-3": "말차 특유의 감미롭고 진한 향은 신선하면서도 쓴맛의 조화로 느껴집니다.",
+                    "paragraph-4": "우리 몸과 마음을 건강하고 초록 기운으로 가득 채워보세요."
+                }
+            },
+            "feature": {
+                "item-1": {
+                    "title": "유기농 첫순 1번 잎",
+                    "description": "서귀포 생태농원에서 재배한 100% 유기농 첫순 1번 잎으로 생산해 더 부드럽고 진한 맛을 담아냅니다."
+                },
+                "item-2": {
+                    "title": "지속 가능한 미래",
+                    "description": "환경을 생각하는 현지 농부 및 장인과 협력해 더 건강하고 지속 가능한 미래를 향해 함께 나아갑니다."
+                },
+                "item-3": {
+                    "title": "품질에 대한 약속",
+                    "description": "오랜 노하우를 이용한 가공 기법과 유통 관리를 통해 최고 품질의 말차를 만들어 냅니다."
+                }
+            }
+        },
+        "history": {
+            "title": "GLOSSY HISTORY",
+            "location": "제주특별자치도 제주시 조천읍 조함해안로 112 일대 (약 1천평)",
+            "list": {
+                "item-1": {
+                    "date": "2023.09",
+                    "desc-1": "'GLOSSY MATCHA' OPENING"
+                },
+                "item-2": {
+                    "date": "2024.09",
+                    "desc-1": "Select shop 'WITH GLOSSY' OPENING"
+                },
+                "item-3": {
+                    "date": "2024.12",
+                    "desc": "당 해년도 수출실적 2만불 달성 (GLOSSY MATCHA 제품 포함)"
+                },
+                "item-4": {
+                    "date": "2025.01",
+                    "desc": "2025 SIRHA 참여 (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)"
+                },
+                "item-5": {
+                    "date": "2025.05",
+                    "desc": "미국, 프랑스 POP-UP 진행 및 후속 수출 물량 협의"
+                },
+                "item-6": {
+                    "date": "2025.06",
+                    "desc": "Lifestyle shoes collabo' 제품 출시 예정 (w 뮬보이, 초록색 말차color 슬리퍼)"
+                }
+            }
+        }
+    }
 }

--- a/fe/messages/ko.json
+++ b/fe/messages/ko.json
@@ -112,32 +112,35 @@
         "history": {
             "title": "GLOSSY HISTORY",
             "location": "제주특별자치도 제주시 조천읍 조함해안로 112 일대 (약 1천평)",
-            "list": {
-                "item-1": {
-                    "date": "2023.09",
-                    "desc-1": "'GLOSSY MATCHA' OPENING"
-                },
-                "item-2": {
+            "items": [
+                { "date": "2023.09", "desc": ["'GLOSSY MATCHA' OPENING"] },
+                {
                     "date": "2024.09",
-                    "desc-1": "Select shop 'WITH GLOSSY' OPENING"
+                    "desc": ["Select shop 'WITH GLOSSY' OPENING"]
                 },
-                "item-3": {
+                {
                     "date": "2024.12",
-                    "desc": "당 해년도 수출실적 2만불 달성 (GLOSSY MATCHA 제품 포함)"
+                    "desc": [
+                        "당 해년도 수출실적 2만불 달성 (GLOSSY MATCHA 제품 포함)"
+                    ]
                 },
-                "item-4": {
+                {
                     "date": "2025.01",
-                    "desc": "2025 SIRHA 참여 (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)"
+                    "desc": [
+                        "2025 SIRHA 참여 (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)"
+                    ]
                 },
-                "item-5": {
+                {
                     "date": "2025.05",
-                    "desc": "미국, 프랑스 POP-UP 진행 및 후속 수출 물량 협의"
+                    "desc": ["미국, 프랑스 POP-UP 진행 및 후속 수출 물량 협의"]
                 },
-                "item-6": {
+                {
                     "date": "2025.06",
-                    "desc": "Lifestyle shoes collabo' 제품 출시 예정 (w 뮬보이, 초록색 말차color 슬리퍼)"
+                    "desc": [
+                        "Lifestyle shoes collabo' 제품 출시 예정 (w 뮬보이, 초록색 말차color 슬리퍼)"
+                    ]
                 }
-            }
+            ]
         }
     }
 }

--- a/fe/src/app/[locale]/about/page.tsx
+++ b/fe/src/app/[locale]/about/page.tsx
@@ -16,12 +16,7 @@ import styles from "./page.module.scss";
  */
 export default function About() {
     /** 스크롤 네비게이션에 표시될 메뉴 항목들 */
-    const mainMenuItems = [
-        { label: "브랜드 소개", href: "#brand-intro" },
-        { label: "브랜드 철학", href: "#philosophy" },
-        { label: "제주 유기농 말차", href: "#jeju-matcha" },
-        { label: "연혁", href: "#history" },
-    ];
+    const menuKeys = ["intro", "philosophy", "jeju-matcha", "history"];
 
     return (
         <main>
@@ -36,7 +31,7 @@ export default function About() {
                     priority
                 />
             </section>
-            <ScrollNav menuItems={mainMenuItems} />
+            <ScrollNav menuKeys={menuKeys} />
             <BrandIntro />
             <BrandPhilosophy />
             <JejuMatcha />

--- a/fe/src/components/About/BrandHistory.tsx
+++ b/fe/src/components/About/BrandHistory.tsx
@@ -1,35 +1,9 @@
+"use client";
+
 import Image from "next/image";
 import { HistoryItem } from "@/types/history";
+import { useTranslations } from "next-intl";
 import styles from "./BrandHistory.module.scss";
-
-/**
- * 브랜드 연혁 데이터 배열
- * 글로시 말차의 주요 이정표와 성과를 시간순으로 정리한 데이터
- */
-const historyItems: HistoryItem[] = [
-    { date: "2023.09", desc: ["'GLOSSY MATCHA' OPENING"] },
-    { date: "2024.09", desc: ["Select shop 'WITH GLOSSY' OPENING"] },
-    {
-        date: "2024.12",
-        desc: ["당 해년도 수출실적 2만불 달성 (GLOSSY MATCHA 제품 포함)"],
-    },
-    {
-        date: "2025.01",
-        desc: [
-            "2025 SIRHA 참여 (Salon International de la Restauration, de l'Hôtellerie et de l'Alimentation)",
-        ],
-    },
-    {
-        date: "2025.05",
-        desc: ["미국, 프랑스 POP-UP 진행 및 후속 수출 물량 협의"],
-    },
-    {
-        date: "2025.06",
-        desc: [
-            "Lifestyle shoes collabo' 제품 출시 예정 (w 뮬보이, 초록색 말차color 슬리퍼)",
-        ],
-    },
-];
 
 /**
  * 브랜드 연혁 섹션 컴포넌트
@@ -40,22 +14,26 @@ const historyItems: HistoryItem[] = [
  * @returns 브랜드 연혁 섹션 컴포넌트
  */
 export default function BrandHistory() {
+    const t = useTranslations("about.history");
+
+    const historyItems = t.raw("items") as HistoryItem[];
+
     return (
         <section id="history" className={styles["brand-history"]}>
             <Image
                 className={styles["brand-history__image"]}
                 src="/images/about/glossy-matcha.webp"
-                alt="글로시말차 카페 전경 이미지"
+                alt={t("title") + " 카페 전경 이미지"}
                 width={960}
                 height={800}
             />
 
             <div className={styles["brand-history__content"]}>
                 <h3 className={styles["brand-history__title"]}>
-                    GLOSSY HISTORY
+                    {t("title")}
                 </h3>
                 <p className={styles["brand-history__location"]}>
-                    제주특별자치도 제주시 조천읍 조함해안로 112 일대 (약 1천평)
+                    {t("location")}
                 </p>
 
                 <ul className={styles["brand-history__list"]}>

--- a/fe/src/components/About/BrandIntro.tsx
+++ b/fe/src/components/About/BrandIntro.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import styles from "./BrandIntro.module.scss";
 
 /**
@@ -9,6 +12,8 @@ import styles from "./BrandIntro.module.scss";
  * @returns 브랜드 소개 섹션 컴포넌트
  */
 export default function BrandIntro() {
+    const t = useTranslations("about.intro");
+
     return (
         <section id="brand-intro" className={styles["brand-intro"]}>
             <h3 className="sr-only">브랜드 소개</h3>
@@ -21,33 +26,23 @@ export default function BrandIntro() {
             />
 
             <div className={styles["brand-intro__content"]}>
-                <h4 className={styles["brand-intro__title"]}>
-                    LIFE WITH GLOSSY
-                </h4>
+                <h4 className={styles["brand-intro__title"]}>{t("title")}</h4>
                 <p className={styles["brand-intro__slogan"]}>
-                    &ldquo;모든 일상을 빛나는 순간으로 만듭니다.&rdquo;
+                    &ldquo;{t("slogan")}&rdquo;
                 </p>
 
                 <div className={styles["brand-intro__description"]}>
                     <p className={styles["brand-intro__paragraph"]}>
-                        글로시말차는 모든 사람들을 위해 반짝이는 에너지를
-                        제공하여 개인만의 즐거움과 기쁨을 찾고 그들의 모든
-                        순간을 빛나게 도와줍니다.
+                        {t("description.paragraph-1")}
                     </p>
                     <p className={styles["brand-intro__paragraph"]}>
-                        일상을 빛나게 만들어 줄 글로시말차는 단순히 말차를
-                        판매하는 브랜드가 아닌 다양한 감성과 컨텐츠가 담긴
-                        관계적 브랜드로 성장할 것을 약속합니다.
+                        {t("description.paragraph-2")}
                     </p>
                     <p className={styles["brand-intro__paragraph"]}>
-                        당신의 삶, 사소한 일상과 순간에서 반짝거림을 찾을 수
-                        있도록 글로시말차는 작은 것들부터 함께 시작하려고
-                        합니다.
+                        {t("description.paragraph-3")}
                     </p>
                     <p className={styles["brand-intro__paragraph"]}>
-                        우리는 제품, 컨텐츠, 캠페인 그리고 당신의 일상이 될 수
-                        있도록 지속가능한 공생을 위한 진전성있는 것들을
-                        제공하는 브랜드입니다.
+                        {t("description.paragraph-4")}
                     </p>
                 </div>
             </div>

--- a/fe/src/components/About/BrandPhilosophy.tsx
+++ b/fe/src/components/About/BrandPhilosophy.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import styles from "./BrandPhilosophy.module.scss";
 
 /**
@@ -9,11 +12,13 @@ import styles from "./BrandPhilosophy.module.scss";
  * @returns 브랜드 철학 섹션 컴포넌트
  */
 export default function BrandPhilosophy() {
+    const t = useTranslations("about.philosophy");
+
     return (
         <section id="philosophy" className={styles["brand-philosophy"]}>
             <div className={styles["brand-philosophy__content"]}>
                 <h3 className={styles["brand-philosophy__title"]}>
-                    GLOSSY LIFE, GLOSSY MATCHA
+                    {t("title")}
                 </h3>
 
                 <div className={styles["brand-philosophy__list"]}>
@@ -24,11 +29,11 @@ export default function BrandPhilosophy() {
                                     styles["brand-philosophy__item-title"]
                                 }
                             >
-                                LIGHT
+                                {t("list.item-1.title")}
                             </h4>
                         </div>
                         <p className={styles["brand-philosophy__item-desc"]}>
-                            제주, 그리고 일상의 빛나는 순간을 지향합니다.
+                            {t("list.item-1.desc")}
                         </p>
                     </article>
 
@@ -39,12 +44,11 @@ export default function BrandPhilosophy() {
                                     styles["brand-philosophy__item-title"]
                                 }
                             >
-                                NATURAL
+                                {t("list.item-2.title")}
                             </h4>
                         </div>
                         <p className={styles["brand-philosophy__item-desc"]}>
-                            자연과 함께할 수 있는 방향을 항상 고민하고
-                            연구합니다.
+                            {t("list.item-2.desc")}
                         </p>
                     </article>
 
@@ -55,11 +59,11 @@ export default function BrandPhilosophy() {
                                     styles["brand-philosophy__item-title"]
                                 }
                             >
-                                TRAVEL
+                                {t("list.item-3.title")}
                             </h4>
                         </div>
                         <p className={styles["brand-philosophy__item-desc"]}>
-                            여행과 함께 할 수 있는 라이프스타일을 제공합니다.
+                            {t("list.item-3.desc")}
                         </p>
                     </article>
                 </div>

--- a/fe/src/components/About/JejuMatcha.module.scss
+++ b/fe/src/components/About/JejuMatcha.module.scss
@@ -60,7 +60,7 @@
             align-items: center;
             width: 100%;
             max-width: 50vw;
-            padding: 0 clamp(20px, 10vw, 190px);
+            padding: 0 clamp(20px, 5vw, 150px);
         }
 
         &-item {
@@ -73,7 +73,7 @@
         }
 
         &-title {
-            @include myeongjo(clamp(28px, 2.6vw, 50px), 500);
+            @include myeongjo(clamp(20px, 2.6vw, 50px), 500);
             color: $color-green-500;
         }
 

--- a/fe/src/components/About/JejuMatcha.tsx
+++ b/fe/src/components/About/JejuMatcha.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import styles from "./JejuMatcha.module.scss";
 
 /**
@@ -11,6 +14,8 @@ import styles from "./JejuMatcha.module.scss";
  * @returns 제주 유기농 말차 소개 컴포넌트
  */
 export default function JejuMatcha() {
+    const t = useTranslations("about.jeju-matcha");
+
     return (
         <>
             {/* 말차 소개 및 브랜드 메시지 섹션 */}
@@ -26,29 +31,24 @@ export default function JejuMatcha() {
 
                 <div className={styles["jeju-matcha__content"]}>
                     <h4 className={styles["jeju-matcha__title"]}>
-                        RELAX WITH GLOSSY
+                        {t("intro.title")}
                     </h4>
                     <p className={styles["jeju-matcha__slogan"]}>
-                        &ldquo;글로시말차는 진정한 휴식을 선물합니다.&rdquo;
+                        &ldquo;{t("intro.slogan")}&rdquo;
                     </p>
 
                     <div className={styles["jeju-matcha__description"]}>
                         <p className={styles["jeju-matcha__paragraph"]}>
-                            말차는 제주에서 가장 우수한 차입니다. 글로시말차는
-                            최고 품질의 100% 유기농 말차만을 사용하고 있습니다.
+                            {t("intro.description.paragraph-1")}
                         </p>
                         <p className={styles["jeju-matcha__paragraph"]}>
-                            제주의 청정 자연이 빚어낸 푸른 생명력을 그대로
-                            담았습니다. 편안함을 선사하는 초록색의 향기는
-                            모두에게 편안한 휴식을 선사합니다.
+                            {t("intro.description.paragraph-2")}
                         </p>
                         <p className={styles["jeju-matcha__paragraph"]}>
-                            말차 특유의 감미롭고 진한 향은 신선하면서도 쓴맛의
-                            조화로 느껴집니다.
+                            {t("intro.description.paragraph-3")}
                         </p>
                         <p className={styles["jeju-matcha__paragraph"]}>
-                            우리 몸과 마음을 건강하고 초록 기운으로 가득
-                            채워보세요.
+                            {t("intro.description.paragraph-4")}
                         </p>
                     </div>
                 </div>
@@ -60,43 +60,40 @@ export default function JejuMatcha() {
                 <div className={styles["jeju-matcha__feature-list"]}>
                     <article className={styles["jeju-matcha__feature-item"]}>
                         <h4 className={styles["jeju-matcha__feature-title"]}>
-                            유기농 첫순 1번 잎
+                            {t("feature.item-1.title")}
                         </h4>
                         <p
                             className={
                                 styles["jeju-matcha__feature-description"]
                             }
                         >
-                            서귀포 생태농원에서 재배한 100% 유기농 첫순 1번
-                            잎으로 생산해 더 부드럽고 진한 맛을 담아냅니다.
+                            {t("feature.item-1.description")}
                         </p>
                     </article>
 
                     <article className={styles["jeju-matcha__feature-item"]}>
                         <h4 className={styles["jeju-matcha__feature-title"]}>
-                            지속 가능한 미래
+                            {t("feature.item-2.title")}
                         </h4>
                         <p
                             className={
                                 styles["jeju-matcha__feature-description"]
                             }
                         >
-                            환경을 생각하는 현지 농부 및 장인과 협력해 더
-                            건강하고 지속 가능한 미래를 향해 함께 나아갑니다.
+                            {t("feature.item-2.description")}
                         </p>
                     </article>
 
                     <article className={styles["jeju-matcha__feature-item"]}>
                         <h4 className={styles["jeju-matcha__feature-title"]}>
-                            품질에 대한 약속
+                            {t("feature.item-3.title")}
                         </h4>
                         <p
                             className={
                                 styles["jeju-matcha__feature-description"]
                             }
                         >
-                            오랜 노하우를 이용한 가공 기법과 유통 관리를 통해
-                            최고 품질의 말차를 만들어 냅니다.
+                            {t("feature.item-3.description")}
                         </p>
                     </article>
                 </div>

--- a/fe/src/components/Nav/ScrollNav.tsx
+++ b/fe/src/components/Nav/ScrollNav.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import styles from "./Nav.module.scss";
 
 /**
@@ -18,9 +19,11 @@ interface MenuItem {
  * ScrollNav 컴포넌트의 props 인터페이스
  */
 interface ScrollNavProps {
-    /** 네비게이션에 표시할 메뉴 항목 배열 */
-    menuItems: MenuItem[];
+    menuKeys: string[];
 }
+
+/** 고정된 네비게이션 바의 높이 (스크롤 오프셋 보정용) */
+const NAV_HEIGHT = 130;
 
 /**
  * 섹션에 스크롤 이동 및 현재 위치에 따른 메뉴 활성화 기능을 제공하는 ScrollNav 컴포넌트
@@ -28,14 +31,15 @@ interface ScrollNavProps {
  * @param {ScrollNavProps} props - 메뉴 항목을 전달하는 props
  * @returns {JSX.Element} - ScrollNav 네비게이션 컴포넌트
  */
-export default function ScrollNav({
-    menuItems,
-}: ScrollNavProps): React.JSX.Element {
+export default function ScrollNav({ menuKeys }: ScrollNavProps) {
     /** 현재 활성화된 섹션의 id */
     const [activeId, setActiveId] = useState<string | null>(null);
+    const t = useTranslations("about");
 
-    /** 고정된 네비게이션 바의 높이 (스크롤 오프셋 보정용) */
-    const NAV_HEIGHT = 130;
+    const menuItems: MenuItem[] = menuKeys.map((key) => ({
+        label: t(`sub-nav.${key}`),
+        href: `#${key === "intro" ? "brand-intro" : key}`,
+    }));
 
     /**
      * 메뉴 항목 클릭 시 부드럽게 해당 섹션으로 스크롤 이동
@@ -79,7 +83,7 @@ export default function ScrollNav({
                     }
                 });
             },
-            { threshold: 0.3 } // 최소 30% 이상 보여야 활성화 처리
+            { threshold: 0.3 }
         );
 
         const targets = menuItems
@@ -96,13 +100,15 @@ export default function ScrollNav({
             <ul className={styles.menuList}>
                 {menuItems.map((item) => {
                     const id = item.href.replace("#", "");
+                    const isActive = activeId === id;
+
                     return (
                         <li key={item.href}>
                             <Link
                                 href={item.href}
                                 scroll={false}
                                 className={`${styles.menuItem} ${
-                                    activeId === id ? styles.active : ""
+                                    isActive ? styles.active : ""
                                 }`}
                                 onClick={(e) => handleClick(e, item.href)}
                             >


### PR DESCRIPTION
## 브랜드 소개 페이지 국영문 전환 구현
- 각 컴포넌트(BrandIntro, BrandPhilosophy, JejuMatcha, BrandHistory) 번역문 작성
- `useTranslations` 훅을 사용해 각 컴포넌트 국영문 전환 구현
- JejuMatcha 컴포넌트 반응형 스타일링 수정