### PR TITLE
[BE] feat: 월/연별 매출 데이터 차트 및 엑셀 파일 내보내기 templates 추가

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/base.html
+++ b/be/glossymatcha/templates/glossymatcha/base.html
@@ -13,6 +13,9 @@
     {% load static %}
     <link rel="stylesheet" href="{% static 'glossymatcha/css/style.css' %}">
     
+    <!-- Chart.js CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    
     {% block extra_css %}{% endblock %}
 </head>
 <body style="background-color: #f2efe8;">

--- a/be/glossymatcha/templates/glossymatcha/dashboard.html
+++ b/be/glossymatcha/templates/glossymatcha/dashboard.html
@@ -116,6 +116,108 @@
     </div>
 </div>
 
+<!-- 매출 분석 대시보드 -->
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0"><i class="bi bi-graph-up-arrow me-2"></i>매출 분석</h5>
+                <div>
+                    <a href="{% url 'monthly_sales_excel_export' %}" class="btn btn-sm btn-outline-success me-2">
+                        <i class="bi bi-file-earmark-excel me-1"></i>월별 매출 엑셀
+                    </a>
+                    <a href="{% url 'yearly_sales_excel_export' %}" class="btn btn-sm btn-outline-success">
+                        <i class="bi bi-file-earmark-excel me-1"></i>연별 매출 엑셀
+                    </a>
+                </div>
+            </div>
+            <div class="card-body">
+                <!-- 매출 지표 -->
+                <div class="row mb-4">
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card bg-light">
+                            <div class="card-body text-center">
+                                <h6 class="card-title">전월 대비</h6>
+                                <div class="h4 {% if sales_analysis.mom_change >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                    {% if sales_analysis.mom_change >= 0 %}↑{% else %}↓{% endif %} {{ sales_analysis.mom_change|floatformat:1 }}%
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card bg-light">
+                            <div class="card-body text-center">
+                                <h6 class="card-title">전년 동월 대비</h6>
+                                <div class="h4 {% if sales_analysis.yoy_change >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                    {% if sales_analysis.yoy_change >= 0 %}↑{% else %}↓{% endif %} {{ sales_analysis.yoy_change|floatformat:1 }}%
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card bg-light">
+                            <div class="card-body text-center">
+                                <h6 class="card-title">수익률</h6>
+                                <div class="h4 text-primary">{{ sales_analysis.profit_margin|floatformat:1 }}%</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card bg-light">
+                            <div class="card-body text-center">
+                                <h6 class="card-title">원가율</h6>
+                                <div class="h4 text-info">{{ sales_analysis.cost_ratio|floatformat:1 }}%</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- 차트 영역 -->
+                <div class="row">
+                    <div class="col-lg-8 mb-4">
+                        <div class="card">
+                            <div class="card-header">
+                                <ul class="nav nav-tabs card-header-tabs" role="tablist">
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link active" id="monthly-tab" data-bs-toggle="tab" data-bs-target="#monthly-chart" type="button" role="tab">
+                                            월별 매출 트렌드
+                                        </button>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <button class="nav-link" id="daily-tab" data-bs-toggle="tab" data-bs-target="#daily-chart" type="button" role="tab">
+                                            최근 30일 매출
+                                        </button>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="card-body">
+                                <div class="tab-content">
+                                    <div class="tab-pane fade show active" id="monthly-chart" role="tabpanel">
+                                        <canvas id="monthlyChart" height="100"></canvas>
+                                    </div>
+                                    <div class="tab-pane fade" id="daily-chart" role="tabpanel">
+                                        <canvas id="dailyChart" height="100"></canvas>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-4 mb-4">
+                        <div class="card">
+                            <div class="card-header">
+                                <h6 class="mb-0">매출 구성</h6>
+                            </div>
+                            <div class="card-body">
+                                <canvas id="salesCompositionChart" height="200"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- 최근 활동 -->
 <div class="row">
     <div class="col-md-4 mb-4">
@@ -414,6 +516,147 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // 페이지 로드 시 초기 계산
     calculateDashboardSalary();
+});
+
+// Chart.js 스크립트
+const chartData = {{ chart_data|safe }};
+
+// 월별 매출 트렌드 차트
+const monthlyCtx = document.getElementById('monthlyChart').getContext('2d');
+const monthlyChart = new Chart(monthlyCtx, {
+    type: 'line',
+    data: {
+        labels: chartData.monthly.labels,
+        datasets: [{
+            label: '매출',
+            data: chartData.monthly.sales,
+            borderColor: 'rgb(54, 162, 235)',
+            backgroundColor: 'rgba(54, 162, 235, 0.1)',
+            tension: 0.4,
+            fill: true
+        }, {
+            label: '원가',
+            data: chartData.monthly.costs,
+            borderColor: 'rgb(255, 99, 132)',
+            backgroundColor: 'rgba(255, 99, 132, 0.1)',
+            tension: 0.4,
+            fill: false
+        }, {
+            label: '수익',
+            data: chartData.monthly.profits,
+            borderColor: 'rgb(75, 192, 192)',
+            backgroundColor: 'rgba(75, 192, 192, 0.1)',
+            tension: 0.4,
+            fill: false
+        }]
+    },
+    options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+            y: {
+                beginAtZero: true,
+                ticks: {
+                    callback: function(value) {
+                        return value.toLocaleString() + '원';
+                    }
+                }
+            }
+        },
+        plugins: {
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        return context.dataset.label + ': ' + context.parsed.y.toLocaleString() + '원';
+                    }
+                }
+            }
+        }
+    }
+});
+
+// 일별 매출 차트
+const dailyCtx = document.getElementById('dailyChart').getContext('2d');
+const dailyChart = new Chart(dailyCtx, {
+    type: 'bar',
+    data: {
+        labels: chartData.daily.labels,
+        datasets: [{
+            label: '일별 매출',
+            data: chartData.daily.sales,
+            backgroundColor: 'rgba(54, 162, 235, 0.6)',
+            borderColor: 'rgb(54, 162, 235)',
+            borderWidth: 1
+        }]
+    },
+    options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+            y: {
+                beginAtZero: true,
+                ticks: {
+                    callback: function(value) {
+                        return value.toLocaleString() + '원';
+                    }
+                }
+            }
+        },
+        plugins: {
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        return context.parsed.y.toLocaleString() + '원';
+                    }
+                }
+            }
+        }
+    }
+});
+
+// 매출 구성 도넛 차트
+const compositionCtx = document.getElementById('salesCompositionChart').getContext('2d');
+const salesAnalysis = {
+    current_month: {{ sales_analysis.current_month }},
+    current_cost: {{ sales_analysis.current_cost }},
+    current_profit: {{ sales_analysis.current_profit }}
+};
+
+const compositionChart = new Chart(compositionCtx, {
+    type: 'doughnut',
+    data: {
+        labels: ['원가', '수익'],
+        datasets: [{
+            data: [salesAnalysis.current_cost, salesAnalysis.current_profit],
+            backgroundColor: [
+                'rgba(255, 99, 132, 0.8)',
+                'rgba(75, 192, 192, 0.8)'
+            ],
+            borderColor: [
+                'rgb(255, 99, 132)',
+                'rgb(75, 192, 192)'
+            ],
+            borderWidth: 2
+        }]
+    },
+    options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: {
+                position: 'bottom'
+            },
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                        const percentage = ((context.parsed / total) * 100).toFixed(1);
+                        return context.label + ': ' + context.parsed.toLocaleString() + '원 (' + percentage + '%)';
+                    }
+                }
+            }
+        }
+    }
 });
 
 </script>


### PR DESCRIPTION
## 매출 분석 섹션 추가
- 매출 지표 카드: 전월대비, 전년동월대비, 수익률, 원가율
- 엑셀 다운로드 버튼: 월별/연별 매출 엑셀 다운로드 링크
- 차트 영역:
  - 월별 매출 트렌드 (라인 차트)
  - 최근 30일 매출 (바 차트)
  - 매출 구성 (도넛 차트)
---
## Chart.js Script 추가
```
  // 월별 매출 트렌드 차트 - 라인 차트
  const monthlyChart = new Chart(monthlyCtx, {
      type: 'line',
      // 매출/원가/수익 3개 라인 표시
  });
```
```
  // 일별 매출 차트 - 바 차트
  const dailyChart = new Chart(dailyCtx, {
      type: 'bar',
      // 최근 30일 일별 매출 표시
  });
```
```
  // 매출 구성 도넛 차트 - 원가 vs 수익 비율
  const compositionChart = new Chart(compositionCtx, {
      type: 'doughnut',
      // 원가와 수익 비율을 도넛 차트로 표시
  });
```
## Chart.js CDN 추가
```
<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
```