### PR TITLE
[FE] feat: 공유하기 기능 개선 및 공유 URL 동적 생성 적용

### DIFF
--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -9,20 +9,40 @@ import { menuData } from "@/data/menuData";
 import { useMatchaQuiz } from "@/hooks/useMatchaQuiz";
 import { useShare } from "@/hooks/useShare";
 import { useDownload } from "@/hooks/useDownload";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useEffect } from "react";
 import Intro from "./Intro";
 import QuestionSection from "./QuestionSection";
 import ResultSection from "./ResultSection";
 import styles from "./MatchaGenerator.module.scss";
 
 export default function MatchaGenerator() {
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const pathname = usePathname();
+
     const {
         currentStep,
+        setQuizState,
         handleAnswer,
         resetQuiz,
         startQuiz,
         goPrevStep,
         recommendation,
     } = useMatchaQuiz();
+
+    const recommendedMenu = searchParams.get("recommendation");
+
+    useEffect(() => {
+        if (recommendedMenu) {
+            setQuizState({
+                currentStep: 5,
+                answers: {},
+            });
+        }
+    }, [recommendedMenu, setQuizState]);
+
+    const displayedRecommendation = recommendedMenu || recommendation;
 
     const handlePrev = () => {
         goPrevStep();
@@ -33,8 +53,8 @@ export default function MatchaGenerator() {
     const { downloadImage } = useDownload();
 
     const handleShare = () => {
-        if (!recommendation) return;
-        shareResult(recommendation);
+        if (!displayedRecommendation) return;
+        shareResult(displayedRecommendation);
     };
 
     const handleDownload = () => {
@@ -68,6 +88,11 @@ export default function MatchaGenerator() {
         }
     };
 
+    const handleReset = () => {
+        resetQuiz();
+        router.replace(pathname);
+    };
+
     return (
         <main className={styles["matcha-generator"]}>
             <section>
@@ -93,12 +118,12 @@ export default function MatchaGenerator() {
                     />
                 )}
 
-                {currentStep === 5 && recommendation && (
+                {currentStep === 5 && displayedRecommendation && (
                     <ResultSection
-                        menuInfo={menuData[recommendation]}
+                        menuInfo={menuData[displayedRecommendation]}
                         onShare={handleShare}
                         onDownload={handleDownload}
-                        onReset={resetQuiz}
+                        onReset={handleReset}
                     />
                 )}
                 <ToastContainer position="bottom-center" autoClose={2000} />

--- a/fe/src/hooks/useMatchaQuiz.ts
+++ b/fe/src/hooks/useMatchaQuiz.ts
@@ -82,6 +82,7 @@ export const useMatchaQuiz = () => {
 
     return {
         ...quizState,
+        setQuizState,
         handleAnswer,
         resetQuiz,
         startQuiz,

--- a/fe/src/hooks/useShare.ts
+++ b/fe/src/hooks/useShare.ts
@@ -4,13 +4,17 @@ import { toast } from "react-toastify";
 export const useShare = () => {
     const shareResult = useCallback(async (recommendation: string) => {
         const text = `나의 글로시 말차 추천 메뉴는 "${recommendation}"!`;
+        const url =
+            window.location.origin +
+            window.location.pathname +
+            `?recommendation=${encodeURIComponent(recommendation)}`;
 
         if (navigator.share) {
             try {
                 await navigator.share({
                     title: "글로시 말차",
                     text: text,
-                    url: window.location.href,
+                    url,
                 });
                 toast.success("공유가 완료되었어요!");
             } catch (error) {
@@ -18,9 +22,7 @@ export const useShare = () => {
             }
         } else {
             try {
-                await navigator.clipboard.writeText(
-                    text + " " + window.location.href
-                );
+                await navigator.clipboard.writeText(text + " " + url);
                 toast.success("링크가 복사되었어요!");
             } catch (error) {
                 toast.error("링크 복사에 실패했어요!");


### PR DESCRIPTION
- `useShare` 훅 내부 수정
  - 공유 URL 생성 로직 추가 (현재 경로 + 쿼리 파라미터)
  - `shareResult(recommendation)` 호출 시 URL 자동 생성

- `handleShare` 공유하기 호출부 변경
  - `shareResult` 호출 시 URL 인자를 제거하고 추천 메뉴명만 전달