### PR TITLE
[FE] fix: useDownload ios 환경 개선

### DIFF
--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -60,32 +60,10 @@ export default function MatchaGenerator() {
     const handleDownload = () => {
         if (!recommendation) return;
 
-        const isIOS =
-            /iPad|iPhone|iPod/.test(navigator.userAgent) &&
-            !(window as unknown as { MSStream?: unknown }).MSStream;
-
-        if (isIOS) {
-            // iOS는 클릭 이벤트 핸들러에서 즉시 새 탭 열기 (팝업 차단 방지)
-            const newWindow = window.open("", "_blank");
-            if (!newWindow) {
-                alert(
-                    "팝업 차단이 되어 새 탭을 열 수 없습니다. 팝업 허용 후 다시 시도해주세요."
-                );
-                return;
-            }
-            // 새 탭 객체 넘겨서 이미지 렌더링 처리
-            downloadImage(
-                "result-section",
-                `${menuData[recommendation].name}.png`,
-                newWindow
-            );
-        } else {
-            // iOS 외는 그냥 다운로드 처리 (새 탭 없이)
-            downloadImage(
-                "result-section",
-                `${menuData[recommendation].name}.png`
-            );
-        }
+        downloadImage(
+            "result-section",
+            `${menuData[recommendation].name}.png`
+        );
     };
 
     const handleReset = () => {

--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -2,70 +2,40 @@ import { useCallback } from "react";
 import html2canvas from "html2canvas";
 
 export const useDownload = () => {
+    const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
+
     const downloadImage = useCallback(
-        async (
-            elementId: string,
-            fileName: string,
-            newWindow?: Window | null
-        ) => {
+        async (elementId: string, fileName: string) => {
             const element = document.getElementById(elementId);
             if (!element) {
                 alert("저장할 영역을 찾을 수 없습니다.");
-                if (newWindow) newWindow.close();
                 return;
             }
 
-            try {
-                const canvas = await html2canvas(element, {
-                    scale: 2,
-                    useCORS: true,
-                    allowTaint: false,
-                });
-                const dataUrl = canvas.toDataURL("image/png");
+            const canvas = await html2canvas(element, {
+                scale: 2,
+            });
+            const dataUrl = canvas.toDataURL("image/png");
 
+            if (isIOS()) {
+                const newWindow = window.open();
                 if (newWindow) {
-                    newWindow.document.write(`
-                        <html>
-                            <head><title>${fileName}</title></head>
-                            <body style="margin:0; display:flex; justify-content:center; align-items:center; height:100vh; font-family:sans-serif;">
-                                <p>이미지 생성 중...</p>
-                            </body>
-                        </html>
-                    `);
-                    newWindow.document.close();
-
-                    const insertImage = () => {
-                        if (newWindow.closed) return;
-                        try {
-                            newWindow.document.body.innerHTML = `
-                                <img src="${dataUrl}" alt="${fileName}" style="max-width:100%; height:auto; display:block; margin:auto;" />
-                            `;
-                        } catch (e) {
-                            newWindow.document.body.innerHTML =
-                                "<p style='color:red;'>이미지 생성 실패</p>";
-                        }
-                    };
-
-                    newWindow.onload = insertImage;
-
-                    setTimeout(insertImage, 1500);
+                    newWindow.document.title = "추천 결과 이미지";
+                    newWindow.document.body.style.margin = "0";
+                    const img = newWindow.document.createElement("img");
+                    img.src = dataUrl;
+                    img.style.width = "100%";
+                    newWindow.document.body.appendChild(img);
                 } else {
-                    // 새 탭 없이 바로 다운로드 링크 생성
-                    const link = document.createElement("a");
-                    link.href = dataUrl;
-                    link.download = fileName;
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
+                    alert(
+                        "팝업이 차단되었습니다. 브라우저 설정에서 허용해주세요."
+                    );
                 }
-            } catch (error) {
-                console.error("이미지 저장 실패", error);
-                if (newWindow) {
-                    newWindow.document.body.innerHTML =
-                        "<p style='color:red;'>이미지 생성 실패</p>";
-                } else {
-                    alert("이미지 저장에 실패했습니다.");
-                }
+            } else {
+                const link = document.createElement("a");
+                link.href = dataUrl;
+                link.download = `${fileName}.png`;
+                link.click();
             }
         },
         []


### PR DESCRIPTION
## `useDownload` 훅 수정
-  iOS 감지 기능 내장
- iOS에서는 새 탭을 열어 이미지 표시 (팝업 차단 시 안내 메시지 포함)
- Android/PC에서는 기존처럼 바로 이미지 다운로드 처리
- `document.write`대신 DOM API로 새 탭에 이미지 삽입하여 deprecated 경고 해결

## `MatchaGenerator` 컴포넌트 수정
- `handleDownload` 함수 내 iOS 분기 제거
- 단순히 `downloadImage("result-section", fileName)` 호출하도록 변경
- iOS 새 탭 열기, 팝업 차단 처리는 훅 내부로 위임