### PR TITLE
[BE] feat: 메인 대시보드에도 올해 매출 표시되게끔 추가

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/dashboard.html
+++ b/be/glossymatcha/templates/glossymatcha/dashboard.html
@@ -40,10 +40,21 @@
     <div class="col-xl-2 col-md-4 mb-3">
         <div class="card dashboard-card h-100">
             <div class="card-body text-center">
-                <i class="bi bi-graph-up dashboard-icon mb-3"></i>
+                <i class="bi bi-calendar3 dashboard-icon mb-3"></i>
                 <h5 class="card-title">이번 달 매출</h5>
                 <div class="stat-number">{{ monthly_sales|korean_won_with_unit|default:"0원" }}</div>
                 <small class="text-muted">{{ today|date:"Y년 m월" }} 누적 매출</small>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-xl-2 col-md-4 mb-3">
+        <div class="card dashboard-card h-100">
+            <div class="card-body text-center">
+                <i class="bi bi-bar-chart dashboard-icon mb-3"></i>
+                <h5 class="card-title">올해 매출</h5>
+                <div class="stat-number">{{ yearly_sales|korean_won_with_unit|default:"0원" }}</div>
+                <small class="text-muted">{{ today|date:"Y년" }} 누적 매출</small>
             </div>
         </div>
     </div>

--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -51,6 +51,10 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             month=today.month
         ).first()
         monthly_sales = current_month_sales.total_sales if current_month_sales else 0
+        
+        # 이번 연도 매출 집계
+        current_year_sales = YearlySales.objects.filter(year=today.year).first()
+        yearly_sales = current_year_sales.total_sales if current_year_sales else 0
 
         # 최근 매출 현황 (최근 5건 - 일별 매출)
         recent_sales = DailySales.objects.all()[:5]
@@ -74,6 +78,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             'active_suppliers_count': active_suppliers_count,
             'today_sales': today_sales,
             'monthly_sales': monthly_sales,
+            'yearly_sales': yearly_sales,
             'recent_sales': recent_sales,
             'staff_list': staff_list,
             'recent_inquiries': recent_inquiries,


### PR DESCRIPTION
- 이번 연도 매출 집계: YearlySales 모델에서 현재 연도 데이터 조회
- Context 데이터: yearly_sales 변수 추가
- 아이콘: bi-bar-chart (막대 차트 아이콘) 사용