### PR TITLE
[FE] fix: useDownload iOS 새 탭 열기 방식으로 개선

### DIFF
--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -60,10 +60,27 @@ export default function MatchaGenerator() {
     const handleDownload = () => {
         if (!recommendation) return;
 
-        downloadImage(
-            "result-section",
-            `${menuData[recommendation].name}.png`
-        );
+        const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+        if (isIOS) {
+            // 팝업 차단 방지 위해 클릭 핸들러에서 바로 새 탭 열기
+            const newWindow = window.open("", "_blank");
+            if (!newWindow) {
+                alert(
+                    "팝업이 차단되어 새 탭을 열 수 없습니다. 팝업 허용 후 다시 시도해주세요."
+                );
+                return;
+            }
+            // 새 탭 객체 넘겨서 이미지 렌더링 처리
+            downloadImage(
+                "result-section",
+                `${menuData[recommendation]}.png`,
+                newWindow
+            );
+        } else {
+            // iOS 외는 그냥 다운로드 처리
+            downloadImage("result-section", `${menuData[recommendation]}.png`);
+        }
     };
 
     const handleReset = () => {

--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -2,39 +2,34 @@ import { useCallback } from "react";
 import html2canvas from "html2canvas";
 
 export const useDownload = () => {
-    const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
-
     const downloadImage = useCallback(
-        async (elementId: string, fileName: string) => {
+        async (
+            elementId: string,
+            fileName: string,
+            newWindow?: Window | null // 새 탭 객체 optional
+        ) => {
             const element = document.getElementById(elementId);
             if (!element) {
                 alert("저장할 영역을 찾을 수 없습니다.");
                 return;
             }
 
-            const canvas = await html2canvas(element, {
-                scale: 2,
-            });
+            const canvas = await html2canvas(element, { scale: 2 });
             const dataUrl = canvas.toDataURL("image/png");
 
-            if (isIOS()) {
-                const newWindow = window.open();
-                if (newWindow) {
-                    newWindow.document.title = "추천 결과 이미지";
-                    newWindow.document.body.style.margin = "0";
-                    const img = newWindow.document.createElement("img");
-                    img.src = dataUrl;
-                    img.style.width = "100%";
-                    newWindow.document.body.appendChild(img);
-                } else {
-                    alert(
-                        "팝업이 차단되었습니다. 브라우저 설정에서 허용해주세요."
-                    );
-                }
+            if (newWindow) {
+                // 새 탭이 전달되면 이미지 표시용으로 사용
+                newWindow.document.title = fileName;
+                newWindow.document.body.style.margin = "0";
+                const img = newWindow.document.createElement("img");
+                img.src = dataUrl;
+                img.style.width = "100%";
+                newWindow.document.body.appendChild(img);
             } else {
+                // 새 탭이 없으면 바로 다운로드
                 const link = document.createElement("a");
                 link.href = dataUrl;
-                link.download = `${fileName}.png`;
+                link.download = fileName;
                 link.click();
             }
         },


### PR DESCRIPTION
## `MatchaGenerator` 컴포넌트 수정
- iOS 환경에서 클릭 핸들러에서 즉시 새 탭 열도록 변경 (팝업 차단 방지)
- 새 탭 객체를 `downloadImage`에 전달하여 이미지 삽입 처리
- iOS 외에는 기존대로 바로 다운로드 처리