### PR TITLE
[FE] feat: useDownload 훅 구현

### DIFF
--- a/fe/src/components/GlossyPick/MatchaGenerator.tsx
+++ b/fe/src/components/GlossyPick/MatchaGenerator.tsx
@@ -7,6 +7,7 @@ import { questions } from "@/data/questions";
 import { menuData } from "@/data/menuData";
 import { useMatchaQuiz } from "@/hooks/useMatchaQuiz";
 import { useShare } from "@/hooks/useShare";
+import { useDownload } from "@/hooks/useDownload";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
 import Intro from "./Intro";
@@ -48,9 +49,16 @@ export default function MatchaGenerator() {
 
   const { shareResult } = useShare();
 
+  const { downloadImage } = useDownload();
+
   const handleShare = () => {
     if (!displayedRecommendation) return;
     shareResult(displayedRecommendation);
+  };
+
+  const handleDownload = () => {
+    if (!recommendation) return;
+    downloadImage("result-section", "recommend");
   };
 
   const handleReset = () => {
@@ -87,6 +95,7 @@ export default function MatchaGenerator() {
           <ResultSection
             menuInfo={menuData[displayedRecommendation]}
             onShare={handleShare}
+            onDownload={handleDownload}
             onReset={handleReset}
           />
         )}

--- a/fe/src/components/GlossyPick/ResultSection.tsx
+++ b/fe/src/components/GlossyPick/ResultSection.tsx
@@ -5,58 +5,58 @@ import styles from "./ResultSection.module.scss";
 import GlossyPickHeader from "./GlossyPickHeader";
 
 interface ResultSectionProps {
-    menuInfo: MenuInfo;
-    onShare: () => void;
-    onReset: () => void;
+  menuInfo: MenuInfo;
+  onShare: () => void;
+  onDownload: () => void;
+  onReset: () => void;
 }
 
 export default function ResultSection({
-    menuInfo,
-    onShare,
-    onReset,
+  menuInfo,
+  onShare,
+  onDownload,
+  onReset,
 }: ResultSectionProps) {
-    const tMenu = useTranslations("test.menu");
-    const tResult = useTranslations("test.result");
+  const tMenu = useTranslations("test.menu");
+  const tResult = useTranslations("test.result");
 
-    return (
-        <div id="result-section" className={styles.result}>
-            <GlossyPickHeader />
+  return (
+    <div id="result-section" className={styles.result}>
+      <GlossyPickHeader />
 
-            <section className={styles["result__menu"]}>
-                <h4 className={styles.result__title}>{tResult("title")}</h4>
-                <Image
-                    className={styles["result__image"]}
-                    src={menuInfo.image}
-                    alt={`${menuInfo.name} 이미지`}
-                    width={300}
-                    height={360}
-                />
-                <p className={styles["result__menuName"]}>
-                    {tMenu(menuInfo.name)}
-                </p>
-                <div className={styles.result__tags}>
-                    {menuInfo.tags.map((tag, index) => (
-                        <span key={index} className="tag">
-                            {tMenu(tag)}
-                        </span>
-                    ))}
-                </div>
-                <p className={styles.result__menuDescription}>
-                    {tMenu(menuInfo.description)}
-                </p>
-            </section>
-
-            <div
-                className={styles.result__actions}
-                data-html2canvas-ignore="true"
-            >
-                <button onClick={onShare} className="btn-g">
-                    {tResult("share")}
-                </button>
-                <button onClick={onReset} className="btn-g">
-                    {tResult("reset")}
-                </button>
-            </div>
+      <section className={styles["result__menu"]}>
+        <h4 className={styles.result__title}>{tResult("title")}</h4>
+        <Image
+          className={styles["result__image"]}
+          src={menuInfo.image}
+          alt={`${menuInfo.name} 이미지`}
+          width={300}
+          height={360}
+        />
+        <p className={styles["result__menuName"]}>{tMenu(menuInfo.name)}</p>
+        <div className={styles.result__tags}>
+          {menuInfo.tags.map((tag, index) => (
+            <span key={index} className="tag">
+              {tMenu(tag)}
+            </span>
+          ))}
         </div>
-    );
+        <p className={styles.result__menuDescription}>
+          {tMenu(menuInfo.description)}
+        </p>
+      </section>
+
+      <div className={styles.result__actions} data-html2canvas-ignore="true">
+        <button onClick={onShare} className="btn-g">
+          {tResult("share")}
+        </button>
+        <button onClick={onDownload} className="btn-g">
+          {tResult("download")}
+        </button>
+        <button onClick={onReset} className="btn-g">
+          {tResult("reset")}
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/fe/src/hooks/useDownload.ts
+++ b/fe/src/hooks/useDownload.ts
@@ -1,0 +1,65 @@
+import { useCallback } from "react";
+import html2canvas from "html2canvas";
+import { toast } from "react-toastify";
+
+// iOS 여부 체크
+const isIOS = () =>
+  /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+  !(window as Window & { MSStream?: unknown }).MSStream;
+
+// 디바이스별 최적 스케일 계산
+const getOptimalScale = (): number => {
+  const deviceMemory = (navigator as Navigator & { deviceMemory?: number })
+    .deviceMemory;
+  const isLowEndDevice = deviceMemory && deviceMemory <= 4;
+  const pixelRatio = window.devicePixelRatio || 1;
+
+  if (isIOS()) return Math.min(pixelRatio, 1.5);
+  if (isLowEndDevice) return 1;
+  return Math.min(pixelRatio, 2);
+};
+
+export const useDownload = () => {
+  const downloadImage = useCallback(
+    async (elementId: string, fileName: string) => {
+      const element = document.getElementById(elementId);
+      if (!element) {
+        alert("저장할 영역을 찾을 수 없습니다.");
+        return;
+      }
+
+      const canvas = await html2canvas(element, {
+        scale: getOptimalScale(),
+      });
+
+      // iOS + Web Share API 미지원 → 새 탭
+      if (isIOS()) {
+        const dataUrl = canvas.toDataURL("image/png");
+        const newWindow = window.open();
+        if (newWindow) {
+          newWindow.document.title = "추천 결과 이미지";
+          newWindow.document.body.style.margin = "0";
+          const img = newWindow.document.createElement("img");
+          img.src = dataUrl;
+          img.style.width = "100%";
+          newWindow.document.body.appendChild(img);
+        } else {
+          toast.error(
+            "팝업이 차단되었습니다. 브라우저 설정에서 허용해주세요."
+          );
+        }
+        return;
+      }
+
+      // 나머지 환경 → 기존 다운로드
+      const dataUrl = canvas.toDataURL("image/png");
+      const link = document.createElement("a");
+      link.href = dataUrl;
+      link.download = `${fileName}.png`;
+      link.click();
+    },
+    []
+  );
+
+  return { downloadImage };
+};


### PR DESCRIPTION
## useDownload 훅 구현
- `canvas` 스케일 최적화 ( iOS는 1-1.5, 데스크톱은 1-2로 동적 조정 )
- PC, Android: 버튼 클릭 시 png 저장 / iOS: 새 탭에서 수동 저장 
- `MatchaGenerator`에 `useDownload` 훅 연결