### PR TITLE
[BE] fix: 대시보드 반응형 개선

### DIFF
--- a/be/glossymatcha/static/glossymatcha/css/style.css
+++ b/be/glossymatcha/static/glossymatcha/css/style.css
@@ -159,8 +159,76 @@ body {
     border-radius: 12px 12px 0 0;
 }
 
-/* 반응형 테이블 */
+/* 반응형 대시보드 */
+@media (max-width: 576px) {
+    /* 모바일에서 통계 카드는 한 줄에 하나씩 */
+    .dashboard-card .card-body {
+        padding: 1rem 0.75rem;
+    }
+    
+    .dashboard-icon {
+        font-size: 2rem;
+    }
+    
+    .stat-number {
+        font-size: 1.5rem;
+    }
+    
+    /* 빠른 작업 버튼 크기 조정 */
+    .action-buttons .btn {
+        font-size: 0.85rem;
+        padding: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+    
+    /* 차트 컨테이너 높이 조정 */
+    #monthlyChart, #dailyChart {
+        max-height: 250px !important;
+    }
+    
+    #salesCompositionChart {
+        max-height: 200px !important;
+    }
+    
+    /* 모달 내용 조정 */
+    .modal-body {
+        padding: 1rem;
+    }
+    
+    .modal-dialog {
+        margin: 0.5rem;
+    }
+}
+
 @media (max-width: 768px) {
+    /* 태블릿에서 통계 카드는 두 개씩 */
+    .dashboard-stats .col-xl-2 {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+    
+    /* 빠른 작업 버튼 태블릿 최적화 */
+    .quick-actions .col-lg-2 {
+        flex: 0 0 33.333333%;
+        max-width: 33.333333%;
+    }
+    
+    /* 차트 영역 스택 */
+    .chart-container .col-lg-8,
+    .chart-container .col-lg-4 {
+        flex: 0 0 100%;
+        max-width: 100%;
+        margin-bottom: 1rem;
+    }
+    
+    /* 최근 활동 섹션 */
+    .recent-activities .col-md-4 {
+        flex: 0 0 100%;
+        max-width: 100%;
+        margin-bottom: 1.5rem;
+    }
+    
+    /* 테이블 폰트 크기 */
     .table-responsive {
         font-size: 0.9rem;
     }
@@ -168,6 +236,27 @@ body {
     .btn-sm {
         font-size: 0.8rem;
         padding: 0.25rem 0.5rem;
+    }
+    
+    /* 카드 헤더 버튼 크기 조정 */
+    .card-header .btn {
+        font-size: 0.8rem;
+        padding: 0.25rem 0.5rem;
+    }
+}
+
+@media (max-width: 992px) {
+    /* 데스크톱 작은 화면에서 차트 레이아웃 조정 */
+    .sales-analysis .col-lg-3 {
+        flex: 0 0 50%;
+        max-width: 50%;
+        margin-bottom: 1rem;
+    }
+    
+    /* 탭 네비게이션 조정 */
+    .nav-tabs .nav-link {
+        font-size: 0.9rem;
+        padding: 0.5rem 0.75rem;
     }
 }
 

--- a/be/glossymatcha/templates/glossymatcha/dashboard.html
+++ b/be/glossymatcha/templates/glossymatcha/dashboard.html
@@ -14,7 +14,7 @@
 </div>
 
 <!-- 요약 통계 카드 -->
-<div class="row mb-4">
+<div class="row mb-4 dashboard-stats">
     <div class="col-xl-2 col-md-4 mb-3">
         <div class="card dashboard-card h-100">
             <div class="card-body text-center">
@@ -89,34 +89,34 @@
             <div class="card-header">
                 <h5 class="mb-0"><i class="bi bi-lightning me-2"></i>빠른 작업</h5>
             </div>
-            <div class="card-body">
+            <div class="card-body action-buttons">
                 <div class="row">
-                    <div class="col-lg-2 col-md-4 mb-2">
+                    <div class="col-xl-2 col-lg-3 col-md-4 col-6 mb-2">
                         <a href="{% url 'staff_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-person-plus me-2"></i>직원 등록
                         </a>
                     </div>
-                    <div class="col-lg-2 col-md-4 mb-2">
+                    <div class="col-xl-2 col-lg-3 col-md-4 col-6 mb-2">
                         <a href="{% url 'daily_sales_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-calendar-day me-2"></i>일별 매출
                         </a>
                     </div>
-                    <div class="col-lg-2 col-md-4 mb-2">
+                    <div class="col-xl-2 col-lg-3 col-md-4 col-6 mb-2">
                         <a href="{% url 'sales_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-calendar3 me-2"></i>월별 매출
                         </a>
                     </div>
-                    <div class="col-lg-2 col-md-4 mb-2">
+                    <div class="col-xl-2 col-lg-3 col-md-4 col-6 mb-2">
                         <a href="{% url 'yearly_sales_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-bar-chart me-2"></i>연별 매출
                         </a>
                     </div>
-                    <div class="col-lg-2 col-md-4 mb-2">
+                    <div class="col-xl-2 col-lg-3 col-md-4 col-6 mb-2">
                         <a href="{% url 'suppliers_create' %}" class="btn btn-outline-primary w-100">
                             <i class="bi bi-shop-window me-2"></i>거래처 등록
                         </a>
                     </div>
-                    <div class="col-lg-2 col-md-4 mb-2">
+                    <div class="col-xl-2 col-lg-3 col-md-4 col-6 mb-2">
                         <a href="#" class="btn btn-outline-primary w-100" data-bs-toggle="modal" data-bs-target="#workRecordModal">
                             <i class="bi bi-cash me-2"></i>급여 기록
                         </a>
@@ -144,7 +144,7 @@
             </div>
             <div class="card-body">
                 <!-- 매출 지표 -->
-                <div class="row mb-4">
+                <div class="row mb-4 sales-analysis">
                     <div class="col-lg-3 col-md-6 mb-3">
                         <div class="card bg-light">
                             <div class="card-body text-center">
@@ -184,8 +184,8 @@
                 </div>
                 
                 <!-- 차트 영역 -->
-                <div class="row">
-                    <div class="col-lg-8 mb-4">
+                <div class="row chart-container">
+                    <div class="col-lg-8 col-12 mb-4">
                         <div class="card">
                             <div class="card-header">
                                 <ul class="nav nav-tabs card-header-tabs" role="tablist">
@@ -213,7 +213,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-lg-4 mb-4">
+                    <div class="col-lg-4 col-12 mb-4">
                         <div class="card">
                             <div class="card-header">
                                 <h6 class="mb-0">매출 구성</h6>
@@ -230,7 +230,7 @@
 </div>
 
 <!-- 최근 활동 -->
-<div class="row">
+<div class="row recent-activities">
     <div class="col-md-4 mb-4">
         <div class="card">
             <div class="card-header">
@@ -380,7 +380,7 @@
 
 <!-- 급여 기록 입력 모달 -->
 <div class="modal fade" id="workRecordModal" tabindex="-1">
-    <div class="modal-dialog modal-lg">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title"><i class="bi bi-cash me-2"></i>급여 기록 입력</h5>


### PR DESCRIPTION
## CSS 개선
- 모바일 (576px 이하): 통계카드/버튼 크기 최적화, 차트 높이 조정
- 태블릿 (768px 이하): 통계카드 2개씩 배치, 차트 스택형 레이아웃
- 데스크톱 작은 화면 (992px 이하): 매출지표 2×2 배치
---
## HTML 레이아웃 개선:
- 통계카드: col-xl-2 col-md-4 → 반응형 클래스 추가
- 빠른작업 버튼: col-6 클래스로 모바일 2×3 배치
- 차트영역: col-12 클래스로 모바일 전체폭 사용
- 모달: 스크롤 가능하도록 개선