### PR TITLE
[BE] feat: Create dailypw admin

### DIFF
--- a/be/glossymatcha/admin.py
+++ b/be/glossymatcha/admin.py
@@ -1,5 +1,26 @@
 from django.contrib import admin
-from .models import Products, ProductImages, ProductSpecifications
+from .models import Products, ProductImages, ProductSpecifications, DailyPassword
+
+@admin.register(DailyPassword)
+class DailyPasswordAdmin(admin.ModelAdmin):
+    """
+    일일 패스워드 관리 어드민 클래스
+    - 일일 패스워드 목록 페이지에서 표시할 필드: 날짜, 패스워드, 활성화 여부, 생성일
+    - 필터링: 활성화 여부, 날짜"""
+    list_display = ('date', 'password', 'is_active', 'created_at')
+    list_filter = ('is_active', 'date')
+    search_fields = ('date', 'password')
+    readonly_fields = ('created_at',)
+    
+    fieldsets = (
+        ('패스워드 정보', {
+            'fields': ('date', 'password', 'is_active')
+        }),
+        ('시간 정보', {
+            'fields': ('created_at',),
+            'classes': ('collapse',)
+        }),
+    )
 
 class ProductImagesInline(admin.TabularInline):
     """


### PR DESCRIPTION
 ## 각 설정의 역할
- list_display
  - 목록 페이지에서 보여줄 컬럼들
    - 날짜 | 패스워드 | 활성화여부 | 생성일 순으로 표시
```list_display = ('date', 'password', 'is_active', 'created_at')```
---
- list_filter
  - 오른쪽 사이드바에 필터 옵션 추가
    - "활성화 여부"로 필터링
    - "날짜"로 필터링
```list_filter = ('is_active', 'date')```
---
- search_fields
    - 검색 기능 추가
      - 날짜나 패스워드로 검색 가능
```search_fields = ('date', 'password')```
---
- readonly_fields
    - 읽기 전용 필드
      - 생성일은 수정 불가
```readonly_fields = ('created_at',)```
---
- fieldsets
  - 상세 페이지 레이아웃 설정
    - 섹션별로 필드 그룹화
    - "시간 정보"는 접힌 상태로 시작
    ```fieldsets = (
      ('패스워드 정보', {
          'fields': ('date', 'password', 'is_active')
      }),
      ('시간 정보', {
          'fields': ('created_at',),
          'classes': ('collapse',)  # 접었다 펼 수 있음
      }),
  )```