### PR TITLE
[BE] fix: Django 로그아웃 시 일일 비밀번호 세션을 초기화

### DIFF
--- a/be/glossymatcha/templates/glossymatcha/base.html
+++ b/be/glossymatcha/templates/glossymatcha/base.html
@@ -67,7 +67,7 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li>
-                                <form method="post" action="{% url 'logout' %}" class="d-inline">
+                                <form method="post" action="{% url 'custom_logout' %}" class="d-inline">
                                     {% csrf_token %}
                                     <button type="submit" class="dropdown-item" style="border: none; background: none; width: 100%; text-align: left;">
                                         <i class="bi bi-box-arrow-right me-2"></i>로그아웃

--- a/be/glossymatcha/urls.py
+++ b/be/glossymatcha/urls.py
@@ -70,4 +70,5 @@ urlpatterns = [
     path('daily-password/logout/', views.daily_password_logout, name='daily_password_logout'), # 일별 비밀번호 로그아웃
     path('daily-password/management/', views.DailyPasswordManagementView.as_view(), name='daily_password_management'), # 일별 비밀번호 관리
     path('daily-password/create/', views.DailyPasswordCreateView.as_view(), name='daily_password_create'), # 일별 비밀번호 생성
+    path('custom-logout/', views.custom_logout, name='custom_logout'), # 커스텀 로그아웃 (Django + 일일 비밀번호 세션 초기화)
 ]

--- a/be/glossymatcha/views.py
+++ b/be/glossymatcha/views.py
@@ -1432,3 +1432,23 @@ def daily_password_logout(request):
         del request.session['daily_password_date']
     messages.success(request, '일일 패스워드 인증이 해제되었습니다.')
     return redirect('daily_password_check')
+
+def custom_logout(request):
+    """
+    커스텀 로그아웃 뷰
+    - Django 로그아웃과 일일 비밀번호 세션 초기화를 동시에 처리
+    - 로그아웃 후 로그인 페이지로 리다이렉트
+    """
+    from django.contrib.auth import logout
+    
+    # Django 로그아웃
+    logout(request)
+    
+    # 일일 비밀번호 세션 초기화
+    if 'daily_password_verified' in request.session:
+        del request.session['daily_password_verified']
+    if 'daily_password_date' in request.session:
+        del request.session['daily_password_date']
+    
+    messages.success(request, '로그아웃되었습니다.')
+    return redirect('login')


### PR DESCRIPTION
## 동작 방식
- 사용자가 로그아웃 버튼 클릭
- Django 사용자 세션 종료 (logout(request))
- 일일 비밀번호 세션 초기화:
  - daily_password_verified 세션 삭제
  - daily_password_date 세션 삭제
- 로그인 페이지로 리다이렉트