### PR TITLE
[FE] fix: 브랜드 연혁 time 간격 수정

### DIFF
--- a/fe/src/components/About/BrandHistory.module.scss
+++ b/fe/src/components/About/BrandHistory.module.scss
@@ -87,6 +87,7 @@
 
   &__date {
     color: #828282;
+    font-variant-numeric: tabular-nums;
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
- `.brand-history__date`에 `font-variant-numeric: tabular-nums` 적용하여 날짜 숫자의 폭을 고정